### PR TITLE
remove densenet161 duplicate in DENSENET_MODELS

### DIFF
--- a/flash/vision/backbones.py
+++ b/flash/vision/backbones.py
@@ -26,7 +26,7 @@ ROOT_S3_BUCKET = "https://pl-bolts-weights.s3.us-east-2.amazonaws.com"
 MOBILENET_MODELS = ["mobilenet_v2"]
 VGG_MODELS = ["vgg11", "vgg13", "vgg16", "vgg19"]
 RESNET_MODELS = ["resnet18", "resnet34", "resnet50", "resnet101", "resnet152", "resnext50_32x4d", "resnext101_32x8d"]
-DENSENET_MODELS = ["densenet121", "densenet169", "densenet161", "densenet161"]
+DENSENET_MODELS = ["densenet121", "densenet169", "densenet161"]
 TORCHVISION_MODELS = MOBILENET_MODELS + VGG_MODELS + RESNET_MODELS + DENSENET_MODELS
 
 BOLTS_MODELS = ["simclr-imagenet", "swav-imagenet"]


### PR DESCRIPTION
## What does this PR do?
In DENSENET_MODELS densenet161 is duplicated, this removes the duplicate.

Fixes # (issue)
Removes a  duplicate entry of densenet161 In DENSENET_MODELS.

<!--
## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-lash/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
-->

## PR review
 - Yes.