### PR TITLE
Use functools.wraps for wrapper

### DIFF
--- a/flash/core/model.py
+++ b/flash/core/model.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Type, Union
+import functools
 
 import pytorch_lightning as pl
 import torch
@@ -27,6 +28,7 @@ def predict_context(func: Callable) -> Callable:
     to put model in eval mode before running predict and reset to train after.
     """
 
+    @functools.wraps(func)
     def wrapper(self, *args, **kwargs) -> Any:
         self.eval()
         torch.set_grad_enabled(False)


### PR DESCRIPTION
## What does this PR do?

I add functools.wraps for the wrapper function.
This allows to use `??` on model.predict and see the predict function rather than the wrapper.
It also fixes up the type annotations etc.

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-lash/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes?
- [n/a] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [n/a] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
