### PR TITLE
Prototype modifications made for RANZCR kaggle challenge  

### DIFF
--- a/flash/core/classification.py
+++ b/flash/core/classification.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Type, Union
 
+import pytorch_lightning as pl
 import torch
+from torch.nn.functional import binary_cross_entropy_with_logits, cross_entropy
 
+from flash.core.utils import bind_method
 from flash.core.data import TaskDataPipeline
-from flash.core.model import Task
+from flash.core.model import Task, predict_context
 
 
 class ClassificationDataPipeline(TaskDataPipeline):
@@ -31,6 +34,79 @@ class ClassificationDataPipeline(TaskDataPipeline):
 
 
 class ClassificationTask(Task):
+
+    def __init__(
+        self,
+        num_classes: int,
+        model: Optional[torch.nn.Module] = None,
+        loss_fn: Optional[Callable] = None,
+        multilabel: bool = False,
+        optimizer: Type[torch.optim.Optimizer] = torch.optim.SGD,
+        metrics: Union[pl.metrics.Metric, Mapping, Sequence, None] = None,
+        learning_rate: float = 1e-3,
+    ):
+
+        super().__init__(
+            model=model, loss_fn=loss_fn, optimizer=optimizer, metrics=metrics, learning_rate=learning_rate
+        )
+
+        self.num_classes = num_classes
+        self.multilabel = multilabel
+
+        if isinstance(self.loss_fn, Mapping) and not self.loss_fn:
+            self.loss_fn = self.default_loss_fn
+
+    def step(self, batch: Sequence[torch.Tensor], batch_idx: int) -> torch.Tensor:
+        """
+        The training/validation/test step. Override for custom behavior.
+        """
+        x, y = batch
+        if self.multilabel:
+            y = y.float()
+        y_hat = self.forward(x)
+        output = {"y_hat": self.data_pipeline.before_uncollate(y_hat)}
+        losses = {name: l_fn(y_hat, y) for name, l_fn in self.loss_fn.items()}
+        logs = {}
+        for name, metric in self.metrics.items():
+            if isinstance(metric, pl.metrics.Metric):
+                metric(output["y_hat"], y.long())
+                logs[name] = metric  # log the metric itself if it is of type Metric
+            else:
+                logs[name] = metric(y_hat, y)
+        logs.update(losses)
+        if len(losses.values()) > 1:
+            logs["total_loss"] = sum(losses.values())
+            return logs["total_loss"], logs
+        output["loss"] = list(losses.values())[0]
+        output["logs"] = logs
+        output["y"] = y
+        return output
+
+    @predict_context
+    def predict(
+        self,
+        x: Any,
+        batch_idx: Optional[int] = None,
+        skip_collate_fn: bool = False,
+        dataloader_idx: Optional[int] = None,
+        data_pipeline: Optional[ClassificationDataPipeline] = None,
+    ) -> Any:    
+        if self.multilabel:
+            bind_method(self.data_pipeline, 
+                        lambda self, samples: samples.tolist(),
+                        'after_uncollate'
+            )
+        return super().predict(x,
+                      batch_idx,
+                      skip_collate_fn,
+                      dataloader_idx,
+                      self.data_pipeline)
+
+    @property
+    def default_loss_fn(self) -> Callable:
+        if self.multilabel:
+            return binary_cross_entropy_with_logits
+        return cross_entropy
 
     @staticmethod
     def default_pipeline() -> ClassificationDataPipeline:

--- a/flash/core/utils.py
+++ b/flash/core/utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from typing import Callable, Dict, Mapping, Sequence, Union
 
+def bind_method(obj, func, target_func_name=None):
+    setattr(obj, target_func_name or func.__name__, func.__get__(obj, type(obj)))
 
 def get_callable_name(fn_or_class: Union[Callable, object]) -> str:
     return getattr(fn_or_class, "__name__", fn_or_class.__class__.__name__).lower()

--- a/flash/data/__init__.py
+++ b/flash/data/__init__.py
@@ -1,1 +1,1 @@
-from flash.data.data_utils import labels_from_categorical_csv
+from flash.data.data_utils import labels_from_csv

--- a/flash/data/data_utils.py
+++ b/flash/data/data_utils.py
@@ -3,12 +3,13 @@ from typing import Any, Dict, List, Union
 import pandas as pd
 
 
-def labels_from_categorical_csv(
-    csv: str,
-    index_col: str,
-    feature_cols: List,
-    return_dict: bool = True,
-    index_col_collate_fn: Any = None
+def labels_from_csv(
+        csv: str,
+        index_col: str,
+        feature_cols: List,
+        return_dict: bool = True,
+        index_col_collate_fn: Any = None,
+        representation="categorical"
 ) -> Union[Dict, List]:
     """
     Returns a dictionary with {index_col: label} for each entry in the csv.
@@ -31,7 +32,16 @@ def labels_from_categorical_csv(
 
     # everything else is binary
     feature_df = df[feature_cols]
-    labels = feature_df.to_numpy().argmax(1).tolist()
+        
+    labels = feature_df.to_numpy()
+    if representation == "categorical":
+        labels = labels.argmax(1)
+    elif representation == "onehot":
+        pass
+    else:
+        raise ValueError(
+                f"{representation} is not a supported representation." 
+                "Please choose from categorical | onehot")
 
     if return_dict:
         labels = {name: label for name, label in zip(names, labels)}

--- a/flash/vision/backbones.py
+++ b/flash/vision/backbones.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Tuple
+from typing import Any, Optional, Tuple
 
 import torchvision
 from pytorch_lightning.utilities import _BOLTS_AVAILABLE, rank_zero_warn
@@ -123,7 +123,7 @@ def torchvision_backbone_and_num_features(model_name: str, pretrained: bool = Tr
     if model_name in MOBILENET_MODELS + VGG_MODELS:
         model = model(pretrained=pretrained)
         backbone = model.features
-        num_features = 512 if model_name in VGG_MODELS else model.classifier[-1].in_features
+        num_features = model.classifier[-1].in_features
         return backbone, num_features
 
     elif model_name in RESNET_MODELS:

--- a/flash/vision/classification/model.py
+++ b/flash/vision/classification/model.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Mapping, Sequence, Type, Union, Tuple
-
+from typing import Any, Callable, Mapping, Sequence, Type, Union, Optional, Tuple
+import sys
+import inspect
 import torch
+from pytorch_lightning.metrics import Accuracy
 from torch import nn
 from torch.nn import functional as F
-from torch.nn.functional import softmax
-from torchmetrics import Accuracy
 
 from flash.core.classification import ClassificationTask
 from flash.vision.backbones import backbone_and_num_features
@@ -27,27 +27,6 @@ from flash.vision.classification.data import ImageClassificationData, ImageClass
 class ImageClassifier(ClassificationTask):
     """Task that classifies images.
 
-    Use a built in backbone
-
-    Example::
-
-        from flash.vision import ImageClassifier
-
-        classifier = ImageClassifier(backbone='resnet18')
-
-    Or your own backbone (num_features is the number of features produced by your backbone)
-
-    Example::
-
-        from flash.vision import ImageClassifier
-        from torch import nn
-
-        # use any backbone
-        some_backbone = nn.Conv2D(...)
-        num_out_features = 1024
-        classifier = ImageClassifier(backbone=(some_backbone, num_out_features))
-
-
     Args:
         num_classes: Number of classes to classify.
         backbone: A string or (model, num_features) tuple to use to compute image features, defaults to ``"resnet18"``.
@@ -55,7 +34,7 @@ class ImageClassifier(ClassificationTask):
         loss_fn: Loss function for training, defaults to :func:`torch.nn.functional.cross_entropy`.
         optimizer: Optimizer to use for training, defaults to :class:`torch.optim.SGD`.
         metrics: Metrics to compute for training and evaluation,
-            defaults to :class:`torchmetrics.Accuracy`.
+            defaults to :class:`pytorch_lightning.metrics.Accuracy`.
         learning_rate: Learning rate to use for training, defaults to ``1e-3``.
     """
 
@@ -64,35 +43,50 @@ class ImageClassifier(ClassificationTask):
         num_classes: int,
         backbone: Union[str, Tuple[nn.Module, int]] = "resnet18",
         pretrained: bool = True,
-        loss_fn: Callable = F.cross_entropy,
+        loss_fn: Optional[Callable] = None,
         optimizer: Type[torch.optim.Optimizer] = torch.optim.SGD,
         metrics: Union[Callable, Mapping, Sequence, None] = Accuracy(),
         learning_rate: float = 1e-3,
+        create_head: bool = True,
+        multilabel: bool = False,
     ):
         super().__init__(
+            num_classes=num_classes,
             model=None,
             loss_fn=loss_fn,
             optimizer=optimizer,
             metrics=metrics,
             learning_rate=learning_rate,
+            multilabel=multilabel,
         )
 
         self.save_hyperparameters()
 
+        # This is very hacky 
+        calling_function = inspect.getframeinfo(sys._getframe(1))[2]
+        if calling_function == "_load_model_state":
+            pretrained = False 
+        
         if isinstance(backbone, tuple):
             self.backbone, num_features = backbone
         else:
             self.backbone, num_features = backbone_and_num_features(backbone, pretrained=pretrained)
 
-        self.head = nn.Sequential(
-            nn.AdaptiveAvgPool2d((1, 1)),
-            nn.Flatten(),
-            nn.Linear(num_features, num_classes),
-        )
+        if create_head:
+            self.head = nn.Sequential(
+                nn.AdaptiveAvgPool2d((1, 1)),
+                nn.Flatten(),
+                nn.Linear(num_features, num_classes),
+            )
+        else:
+            self.head = False
 
     def forward(self, x) -> Any:
         x = self.backbone(x)
-        return softmax(self.head(x))
+        if self.head:
+            return self.head(x)
+        else:
+            return x
 
     @staticmethod
     def default_pipeline() -> ImageClassificationDataPipeline:


### PR DESCRIPTION
Here is the notebook for the competition https://www.kaggle.com/aaronbornstein/iterating-ranzcr-baselines-in-a-flash 

- Multi label support and one hot embedding
- Enable BCE loss with logits (regular BCE breaks with no warning)
- Support for binding and overridng functions
- Loading custom backbones for image classifcaiton  (should be applied to all models)
-Added support not to attach head to model backbone (should be applied to all models)
- prevent  redownloading image classification backbones when loading from checkpoint
- hardcoded support ablumenation transforms for image classification (needs to be cleaned)

Features would make things cleaner
-  LR schedulers - flash doesn’t support this
- Train with folds - flash doesn’t support this and should in it’s datamodule
-  Split data leakage check hook
- native support for timm backbones
- loading large models for inference is slow
- other open issues
