### PR TITLE
Fixed typo on spelling of semantic_segmentation

### DIFF
--- a/docs/source/reference/semantic_segmentation.rst
+++ b/docs/source/reference/semantic_segmentation.rst
@@ -1,14 +1,14 @@
 
-.. _semantinc_segmentation:
+.. _semantic_segmentation:
 
 ######################
-Semantinc Segmentation
+Semantic Segmentation
 ######################
 
 ********
 The task
 ********
-Semantic segmentation, or image segmentation, is the task of performing classification at a pixel-level, meaning each pixel will associated to a given class. The model output shape is ``(batch_size, num_classes, heigh, width)``.
+Semantic Segmentation, or image segmentation, is the task of performing classification at a pixel-level, meaning each pixel will associated to a given class. The model output shape is ``(batch_size, num_classes, heigh, width)``.
 
 See more: https://paperswithcode.com/task/semantic-segmentation
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3045407/117969756-7fde2880-b330-11eb-9e8f-dcf2ae877ac1.png)
