### PR TITLE
Override `add_argparse_args` in the `FlashTrainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [0.3.1] - YYYY-MM-DD
 
+### Fixed
+
+- Fixed `flash.Trainer.add_argparse_args` not adding any arguments ([#343](https://github.com/PyTorchLightning/lightning-flash/pull/343))
+
 
 ## [0.3.0] - 2021-05-20
 

--- a/flash/core/trainer.py
+++ b/flash/core/trainer.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
+from argparse import ArgumentParser
 from functools import wraps
 from typing import Callable, List, Optional, Union
 
 import torch
-from pytorch_lightning import LightningDataModule, LightningModule, Trainer
+from pytorch_lightning import LightningDataModule, LightningModule
+from pytorch_lightning import Trainer as PlTrainer
 from pytorch_lightning.callbacks import BaseFinetuning
 from pytorch_lightning.utilities import rank_zero_warn
-from pytorch_lightning.utilities.argparse import get_init_arguments_and_types, parse_env_variables
+from pytorch_lightning.utilities.argparse import add_argparse_args, get_init_arguments_and_types, parse_env_variables
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from torch.utils.data import DataLoader
 
@@ -49,7 +51,7 @@ def _defaults_from_env_vars(fn: Callable) -> Callable:
     return insert_env_defaults
 
 
-class Trainer(Trainer):
+class Trainer(PlTrainer):
 
     @_defaults_from_env_vars
     def __init__(self, *args, **kwargs):
@@ -172,3 +174,9 @@ class Trainer(Trainer):
         override_types = new_callbacks_types.intersection(old_callbacks_types)
         new_callbacks.extend(c for c in old_callbacks if type(c) not in override_types)
         return new_callbacks
+
+    @classmethod
+    def add_argparse_args(cls, *args, **kwargs) -> ArgumentParser:
+        # the lightning trainer implementation does not support subclasses.
+        # context: https://github.com/PyTorchLightning/lightning-flash/issues/342#issuecomment-848892447
+        return add_argparse_args(PlTrainer, *args, **kwargs)

--- a/tests/core/test_trainer.py
+++ b/tests/core/test_trainer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from argparse import ArgumentParser
 from typing import Any
 
 import pytest
@@ -110,3 +111,10 @@ def test_resolve_callbacks_override_warning(tmpdir):
     task = FinetuneClassificationTask(model, loss_fn=F.nll_loss)
     with pytest.warns(UserWarning, match="The model contains a default finetune callback"):
         trainer._resolve_callbacks(task, "test")
+
+
+def test_add_argparse_args():
+    parser = ArgumentParser()
+    parser = Trainer.add_argparse_args(parser)
+    args = parser.parse_args(['--gpus=1'])
+    assert args.gpus == 1


### PR DESCRIPTION
## What does this PR do?

Hacky fix, but I want to avoid having to implement support for subclasses in Lightning. There is `jsonargparse` for that.

Fixes #342

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)