### PR TITLE
Integrate FiftyOne for loading datasets and visualizing video classification predictions

### DIFF
--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -30,6 +30,12 @@ from flash.core.data.data_pipeline import DataPipeline, DefaultPreprocess, Postp
 from flash.core.data.data_source import DatasetDataSource, DataSource, DefaultDataSources
 from flash.core.data.splits import SplitDataset
 from flash.core.data.utils import _STAGES_PREFIX
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+
+if _FIFTYONE_AVAILABLE:
+    from fiftyone.core.collections import SampleCollection
+else:
+    SampleCollection = None
 
 
 class DataModule(pl.LightningDataModule):
@@ -1009,6 +1015,80 @@ class DataModule(pl.LightningDataModule):
         """
         return cls.from_data_source(
             DefaultDataSources.DATASET,
+            train_dataset,
+            val_dataset,
+            test_dataset,
+            predict_dataset,
+            train_transform=train_transform,
+            val_transform=val_transform,
+            test_transform=test_transform,
+            predict_transform=predict_transform,
+            data_fetcher=data_fetcher,
+            preprocess=preprocess,
+            val_split=val_split,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            **preprocess_kwargs,
+        )
+
+    @classmethod
+    def from_fiftyone(
+        cls,
+        train_dataset: Optional[SampleCollection] = None,
+        val_dataset: Optional[SampleCollection] = None,
+        test_dataset: Optional[SampleCollection] = None,
+        predict_dataset: Optional[SampleCollection] = None,
+        train_transform: Optional[Dict[str, Callable]] = None,
+        val_transform: Optional[Dict[str, Callable]] = None,
+        test_transform: Optional[Dict[str, Callable]] = None,
+        predict_transform: Optional[Dict[str, Callable]] = None,
+        data_fetcher: Optional[BaseDataFetcher] = None,
+        preprocess: Optional[Preprocess] = None,
+        val_split: Optional[float] = None,
+        batch_size: int = 4,
+        num_workers: Optional[int] = None,
+        **preprocess_kwargs: Any,
+    ) -> 'DataModule':
+        """Creates a :class:`~flash.core.data.data_module.DataModule` object
+        from the given FiftyOne Datasets using the
+        :class:`~flash.core.data.data_source.DataSource` of name
+        :attr:`~flash.core.data.data_source.DefaultDataSources.FIFTYONE`
+        from the passed or constructed :class:`~flash.core.data.process.Preprocess`.
+        Args:
+            train_dataset: The FiftyOne Dataset containing the train data.
+            val_dataset: The FiftyOne Dataset containing the validation data.
+            test_dataset: The FiftyOne Dataset containing the test data.
+            predict_dataset: The FiftyOne Dataset containing the predict data.
+            train_transform: The dictionary of transforms to use during training which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            val_transform: The dictionary of transforms to use during validation which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            test_transform: The dictionary of transforms to use during testing which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            predict_transform: The dictionary of transforms to use during predicting which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            data_fetcher: The :class:`~flash.core.data.callback.BaseDataFetcher` to pass to the
+                :class:`~flash.core.data.data_module.DataModule`.
+            preprocess: The :class:`~flash.core.data.data.Preprocess` to pass to the
+                :class:`~flash.core.data.data_module.DataModule`. If ``None``, ``cls.preprocess_cls``
+                will be constructed and used.
+            val_split: The ``val_split`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            batch_size: The ``batch_size`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            num_workers: The ``num_workers`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            preprocess_kwargs: Additional keyword arguments to use when constructing the preprocess. Will only be used
+                if ``preprocess = None``.
+        Returns:
+            The constructed data module.
+        Examples::
+            data_module = DataModule.from_folders(
+                train_folder="train_folder",
+                train_transform={
+                    "to_tensor_transform": torch.as_tensor,
+                },
+            )
+        """
+        return cls.from_data_source(
+            DefaultDataSources.FIFTYONE,
             train_dataset,
             val_dataset,
             test_dataset,

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -42,6 +42,11 @@ from flash.core.data.auto_dataset import AutoDataset, BaseAutoDataset, IterableA
 from flash.core.data.properties import ProcessState, Properties
 from flash.core.data.utils import CurrentRunningStageFuncContext
 
+if _FIFTYONE_AVAILABLE:
+    from fiftyone.core.collections import SampleCollection
+else:
+    SampleCollection = None
+
 
 # Credit to the PyTorchVision Team:
 # https://github.com/pytorch/vision/blob/master/torchvision/datasets/folder.py#L10
@@ -461,3 +466,13 @@ class TensorDataSource(SequenceDataSource[torch.Tensor]):
 class NumpyDataSource(SequenceDataSource[np.ndarray]):
     """The ``NumpyDataSource`` is a ``SequenceDataSource`` which expects the input to
     :meth:`~flash.core.data.data_source.DataSource.load_data` to be a sequence of ``np.ndarray`` objects."""
+
+class FiftyOneDataSource(SequenceDataSource[SampleCollection]):
+    """The ``FiftyOneDataSource`` is a ``SequenceDataSource`` which expects the input to
+    :meth:`~flash.core.data.data_source.DataSource.load_data` to be a sequence
+    of FiftyOne Dataset objects."""
+
+    def predict_load_data(self,
+                          data: SampleCollection,
+                          dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
+        return [{DefaultDataKeys.INPUT: s.filepath} for s in data] 

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -41,6 +41,7 @@ from torch.utils.data.dataset import Dataset
 from flash.core.data.auto_dataset import AutoDataset, BaseAutoDataset, IterableAutoDataset
 from flash.core.data.properties import ProcessState, Properties
 from flash.core.data.utils import CurrentRunningStageFuncContext
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
 
 if _FIFTYONE_AVAILABLE:
     from fiftyone.core.collections import SampleCollection
@@ -150,6 +151,7 @@ class DefaultDataSources(LightningEnum):
     CSV = "csv"
     JSON = "json"
     DATASET = "dataset"
+    FIFTYONE = "fiftyone"
 
     # TODO: Create a FlashEnum class???
     def __hash__(self) -> int:

--- a/flash/core/utilities/imports.py
+++ b/flash/core/utilities/imports.py
@@ -75,6 +75,7 @@ _PYTORCHVIDEO_AVAILABLE = _module_available("pytorchvideo")
 _MATPLOTLIB_AVAILABLE = _module_available("matplotlib")
 _TRANSFORMERS_AVAILABLE = _module_available("transformers")
 _PYSTICHE_AVAILABLE = _module_available("pystiche")
+_FIFTYONE_AVAILABLE = _module_available("fiftyone")
 
 if Version:
     _TORCHVISION_GREATER_EQUAL_0_9 = _compare_version("torchvision", operator.ge, "0.9.0")

--- a/flash/video/classification/data.py
+++ b/flash/video/classification/data.py
@@ -20,10 +20,25 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from torch.utils.data import RandomSampler, Sampler
 
 from flash.core.data.data_module import DataModule
-from flash.core.data.data_source import DefaultDataKeys, DefaultDataSources, LabelsState, PathsDataSource
+from flash.core.data.data_source import (
+    DefaultDataKeys, 
+    DefaultDataSources, 
+    FiftyOneDataSource,
+    LabelsState, 
+    PathsDataSource,
+)
 from flash.core.data.process import Preprocess
 from flash.core.data.transforms import merge_transforms
-from flash.core.utilities.imports import _KORNIA_AVAILABLE, _PYTORCHVIDEO_AVAILABLE
+from flash.core.utilities.imports import (
+    _KORNIA_AVAILABLE,
+    _FIFTYONE_AVAILABLE,
+    _PYTORCHVIDEO_AVAILABLE,
+)
+
+if _FIFTYONE_AVAILABLE:
+    from fiftyone.core.collections import SampleCollection
+else:
+    SampleCollection = None
 
 if _KORNIA_AVAILABLE:
     import kornia.augmentation as K


### PR DESCRIPTION
## What does this PR do?

Integrates lightning flash with the analysis and visualization tool, FiftyOne. Primarily adds:
* `VideoClassificationData.from_fiftyone` loading data directly from FiftyOne datasets
* `FiftyOneLabels()` serializer returning predictions in the FiftyOne Classification(s) format

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
