### PR TITLE
enforce random sampling at first call in kornia parallell transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Changed the installation command for extra features ([#346](https://github.com/PyTorchLightning/lightning-flash/pull/346))
-
-
 - Fixed a bug where the translation task wasn't decoding tokens properly ([#332](https://github.com/PyTorchLightning/lightning-flash/pull/332))
-
-
 - Fixed a bug where huggingface tokenizers were sometimes being pickled ([#332](https://github.com/PyTorchLightning/lightning-flash/pull/332))
+- Fixed issue with `KorniaParallelTransforms` to assure to share the random state between transforms ([#351](https://github.com/PyTorchLightning/lightning-flash/pull/351))
+- Change resize interpolation default mode to nearest ([#352](https://github.com/PyTorchLightning/lightning-flash/pull/352))
 
 
 ## [0.3.0] - 2021-05-20

--- a/flash/core/data/transforms.py
+++ b/flash/core/data/transforms.py
@@ -79,7 +79,7 @@ class KorniaParallelTransforms(nn.Sequential):
         for transform in self.children():
             inputs = result
 
-            # we enforce the firs time to sample random params
+            # we enforce the first time to sample random params
             result[0] = transform(inputs[0])
 
             if hasattr(transform, "_params") and bool(transform._params):

--- a/flash/core/data/transforms.py
+++ b/flash/core/data/transforms.py
@@ -73,30 +73,27 @@ class KorniaParallelTransforms(nn.Sequential):
 
     def __init__(self, *args):
         super().__init__(*[convert_to_modules(arg) for arg in args])
-        self._reuse_params: bool = False
-
-    @property
-    def reuse_params(self) -> bool:
-        return self._reuse_params
-
-    def set_reuse_params(self, val: bool):
-        self._reuse_params = val
 
     def forward(self, inputs: Any):
         result = list(inputs) if isinstance(inputs, Sequence) else [inputs]
         for transform in self.children():
             inputs = result
+
+            # we enforce the firs time to sample random params
+            result[0] = transform(inputs[0])
+
             if hasattr(transform, "_params") and bool(transform._params):
                 params = transform._params
             else:
                 params = None
 
-            for i, input in enumerate(inputs):
+            # apply transforms from (1, n)
+            for i, input in enumerate(inputs[1:]):
                 if params is not None:
-                    result[i] = transform(input, params)
+                    result[i + 1] = transform(input, params)
                 else:  # case for non random transforms
-                    result[i] = transform(input)
-            if not self.reuse_params and hasattr(transform, "_params") and bool(transform._params):
+                    result[i + 1] = transform(input)
+            if hasattr(transform, "_params") and bool(transform._params):
                 transform._params = None
         return result
 

--- a/flash/core/data/transforms.py
+++ b/flash/core/data/transforms.py
@@ -73,6 +73,14 @@ class KorniaParallelTransforms(nn.Sequential):
 
     def __init__(self, *args):
         super().__init__(*[convert_to_modules(arg) for arg in args])
+        self._reuse_params: bool = False
+
+    @property
+    def reuse_params(self) -> bool:
+        return self._reuse_params
+
+    def set_reuse_params(self, val: bool):
+        self._reuse_params = val
 
     def forward(self, inputs: Any):
         result = list(inputs) if isinstance(inputs, Sequence) else [inputs]
@@ -88,7 +96,7 @@ class KorniaParallelTransforms(nn.Sequential):
                     result[i] = transform(input, params)
                 else:  # case for non random transforms
                     result[i] = transform(input)
-            if hasattr(transform, "_params") and bool(transform._params):
+            if not self.reuse_params and hasattr(transform, "_params") and bool(transform._params):
                 transform._params = None
         return result
 

--- a/flash/image/segmentation/transforms.py
+++ b/flash/image/segmentation/transforms.py
@@ -38,7 +38,7 @@ def default_transforms(image_size: Tuple[int, int]) -> Dict[str, Callable]:
         "post_tensor_transform": nn.Sequential(
             ApplyToKeys(
                 [DefaultDataKeys.INPUT, DefaultDataKeys.TARGET],
-                KorniaParallelTransforms(K.geometry.Resize(image_size, interpolation='bilinear')),
+                KorniaParallelTransforms(K.geometry.Resize(image_size, interpolation='nearest')),
             ),
         ),
         "collate": Compose([kornia_collate, ApplyToKeys(DefaultDataKeys.TARGET, prepare_target)]),

--- a/tests/core/data/test_transforms.py
+++ b/tests/core/data/test_transforms.py
@@ -106,6 +106,7 @@ def test_kornia_parallel_transforms(with_params):
     assert transform_b.call_count == 2
 
     if with_params:
+        assert transform_a.call_args_list[1][0][1] == "test"
         # check that after the forward `_params` is set to None
         assert transform_a._params == transform_a._params is None
 

--- a/tests/core/data/test_transforms.py
+++ b/tests/core/data/test_transforms.py
@@ -107,7 +107,7 @@ def test_kornia_parallel_transforms(with_params):
 
     if with_params:
         # check that after the forward `_params` is set to None
-        assert transform_a._params == transform_a._params == None
+        assert transform_a._params == transform_a._params is None
 
     assert torch.allclose(transform_a.call_args_list[0][0][0], samples[0])
     assert torch.allclose(transform_a.call_args_list[1][0][0], samples[1])

--- a/tests/core/data/test_transforms.py
+++ b/tests/core/data/test_transforms.py
@@ -100,6 +100,10 @@ def test_kornia_parallel_transforms(with_params):
         transform_a._params = "test"
 
     parallel_transforms = KorniaParallelTransforms(transform_a, transform_b)
+    assert parallel_transforms.reuse_params is False
+
+    parallel_transforms.set_reuse_params(True)
+    assert parallel_transforms.reuse_params is True
 
     parallel_transforms(samples)
 

--- a/tests/core/data/test_transforms.py
+++ b/tests/core/data/test_transforms.py
@@ -100,11 +100,6 @@ def test_kornia_parallel_transforms(with_params):
         transform_a._params = "test"
 
     parallel_transforms = KorniaParallelTransforms(transform_a, transform_b)
-    assert parallel_transforms.reuse_params is False
-
-    parallel_transforms.set_reuse_params(True)
-    assert parallel_transforms.reuse_params is True
-
     parallel_transforms(samples)
 
     assert transform_a.call_count == 2

--- a/tests/core/data/test_transforms.py
+++ b/tests/core/data/test_transforms.py
@@ -97,7 +97,7 @@ def test_kornia_parallel_transforms(with_params):
     transform_b = Mock(spec=torch.nn.Module)
 
     if with_params:
-        transform_a._params = "test"
+        transform_a._params = "test"  # initialize params with some value
 
     parallel_transforms = KorniaParallelTransforms(transform_a, transform_b)
     parallel_transforms(samples)
@@ -106,7 +106,8 @@ def test_kornia_parallel_transforms(with_params):
     assert transform_b.call_count == 2
 
     if with_params:
-        assert transform_a.call_args_list[0][0][1] == transform_a.call_args_list[1][0][1] == "test"
+        # check that after the forward `_params` is set to None
+        assert transform_a._params == transform_a._params == None
 
     assert torch.allclose(transform_a.call_args_list[0][0][0], samples[0])
     assert torch.allclose(transform_a.call_args_list[1][0][0], samples[1])


### PR DESCRIPTION
## What does this PR do?

enables to reuse the transforms parameters for kornia transforms in different calls

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
