### PR TITLE
change resize interpolation default mode to `nearest`

### DIFF
--- a/flash/image/segmentation/transforms.py
+++ b/flash/image/segmentation/transforms.py
@@ -38,7 +38,7 @@ def default_transforms(image_size: Tuple[int, int]) -> Dict[str, Callable]:
         "post_tensor_transform": nn.Sequential(
             ApplyToKeys(
                 [DefaultDataKeys.INPUT, DefaultDataKeys.TARGET],
-                KorniaParallelTransforms(K.geometry.Resize(image_size, interpolation='bilinear')),
+                KorniaParallelTransforms(K.geometry.Resize(image_size, interpolation='nearest')),
             ),
         ),
         "collate": Compose([kornia_collate, ApplyToKeys(DefaultDataKeys.TARGET, prepare_target)]),


### PR DESCRIPTION
## What does this PR do?

use `nearest` interpolation method in resize by default to avoid artifacts in the data

`nearest`

![image](https://user-images.githubusercontent.com/5157099/120305360-f2f41280-c2d0-11eb-9954-3b7f960474bc.png)

`blinear`

![image](https://user-images.githubusercontent.com/5157099/120305413-03a48880-c2d1-11eb-84b3-c891a65b4456.png)


## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
