### PR TITLE
Adding optional sampler input to DataModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added support for `torch.jit` to tasks where possible and documented task JIT compatibility ([#389](https://github.com/PyTorchLightning/lightning-flash/pull/389))
+- Added option to provide a `Sampler` to the `DataModule` to use when creating a `DataLoader` ([#390](https://github.com/PyTorchLightning/lightning-flash/pull/390))
 
 ### Changed
 

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -264,20 +264,13 @@ class DataModule(pl.LightningDataModule):
 
     def _train_dataloader(self) -> DataLoader:
         train_ds: Dataset = self._train_ds() if isinstance(self._train_ds, Callable) else self._train_ds
+        shuffle: bool = False
         if self.sampler is None:
             shuffle = not isinstance(train_ds, (IterableDataset, IterableAutoDataset))
-            return DataLoader(
-                train_ds,
-                batch_size=self.batch_size,
-                shuffle=shuffle,
-                num_workers=self.num_workers,
-                pin_memory=True,
-                drop_last=True,
-                collate_fn=self._resolve_collate_fn(train_ds, RunningStage.TRAINING)
-            )
         return DataLoader(
             train_ds,
             batch_size=self.batch_size,
+            shuffle=shuffle,
             sampler=self.sampler,
             num_workers=self.num_workers,
             pin_memory=True,

--- a/tests/core/data/test_sampler.py
+++ b/tests/core/data/test_sampler.py
@@ -1,0 +1,32 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from flash import DataModule
+
+
+@mock.patch("flash.core.data.data_module.DataLoader")
+def test_dataloaders_with_sampler(mock_dataloader):
+    train_ds = val_ds = test_ds = 'dataset'
+    mock_sampler = 'sampler'
+    dm = DataModule(train_ds, val_ds, test_ds, num_workers=0, sampler=mock_sampler)
+    assert dm.sampler is mock_sampler
+    dl = dm.train_dataloader()
+    kwargs = mock_dataloader.call_args[1]
+    assert 'sampler' in kwargs
+    assert kwargs['sampler'] is mock_sampler
+    for dl in [dm.val_dataloader(), dm.test_dataloader()]:
+        kwargs = mock_dataloader.call_args[1]
+        assert 'sampler' not in kwargs


### PR DESCRIPTION
## What does this PR do?

This PR adds the option of specifying a sampler to be used in the training `DataLoader` returned by a `DataModule`.

Fixes # [350](https://github.com/PyTorchLightning/lightning-flash/issues/350)

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
