### PR TITLE
Update CI settings for FiftyOne

### DIFF
--- a/.github/workflows/ci-notebook.yml
+++ b/.github/workflows/ci-notebook.yml
@@ -58,6 +58,8 @@ jobs:
         key: flash-datasets_predict
 
     - name: Run Notebooks
+      env:
+          FIFTYONE_DO_NOT_TRACK: true
       run: |
         # jupyter nbconvert --to script flash_notebooks/image_classification.ipynb
         jupyter nbconvert --to script flash_notebooks/tabular_classification.ipynb

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -114,6 +114,8 @@ jobs:
         restore-keys: lightning-flash-datasets-
 
     - name: Tests
+      env:
+          FIFTYONE_DO_NOT_TRACK: true
       run: |
         # tox --sitepackages
         coverage run --source flash -m pytest flash tests -v --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.requires }}.xml

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Test Documentation
         env:
           SPHINX_MOCK_REQUIREMENTS: 0
+          FIFTYONE_DO_NOT_TRACK: true
         run: |
           # First run the same pipeline as Read-The-Docs
           apt-get update && sudo apt-get install -y cmake


### PR DESCRIPTION
## What does this PR do?

One more small change came up related to FiftyOne. 

This PR updates a FiftyOne environment variable in the GitHub CI workflows to prevent them from being logged in our metrics.

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [X] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
