### PR TITLE
Change serve sanity check default to False

### DIFF
--- a/flash/core/trainer.py
+++ b/flash/core/trainer.py
@@ -72,7 +72,7 @@ def _defaults_from_env_vars(fn: Callable) -> Callable:
 class Trainer(PlTrainer):
 
     @_defaults_from_env_vars
-    def __init__(self, *args, serve_sanity_check: bool = True, **kwargs):
+    def __init__(self, *args, serve_sanity_check: bool = False, **kwargs):
         if flash._IS_TESTING:
             if torch.cuda.is_available():
                 kwargs["gpus"] = 1


### PR DESCRIPTION
## What does this PR do?

Serve currently doesn't work from a notebook so the sanity check will fail. This changes the default to false so that the sanity check won't run unless requested

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
