### PR TITLE
Add lazy importing for FiftyOne

### DIFF
--- a/flash/core/classification.py
+++ b/flash/core/classification.py
@@ -21,12 +21,12 @@ from pytorch_lightning.utilities import rank_zero_warn
 from flash.core.data.data_source import DefaultDataKeys, LabelsState
 from flash.core.data.process import Serializer
 from flash.core.model import Task
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
 if _FIFTYONE_AVAILABLE:
-    from fiftyone.core.labels import Classification, Classifications
+    fol = lazy_import("fiftyone.core.labels")
 else:
-    Classification, Classifications = None, None
+    fol = None
 
 
 def binary_cross_entropy_with_logits(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -219,7 +219,7 @@ class FiftyOneLabels(ClassificationSerializer):
     def serialize(
         self,
         sample: Any,
-    ) -> Union[Classification, Classifications, Dict[str, Any], Dict[str, Any]]:
+    ) -> Union[fol.Classification, fol.Classifications, Dict[str, Any], Dict[str, Any]]:
         pred = sample[DefaultDataKeys.PREDS] if isinstance(sample, Dict) else sample
         pred = torch.tensor(pred)
 
@@ -251,12 +251,12 @@ class FiftyOneLabels(ClassificationSerializer):
             if self.multi_label:
                 classifications = []
                 for idx in classes:
-                    fo_cls = Classification(
+                    fo_cls = fol.Classification(
                         label=labels[idx],
                         confidence=probabilities[idx],
                     )
                     classifications.append(fo_cls)
-                fo_predictions = Classifications(
+                fo_predictions = fol.Classifications(
                     classifications=classifications,
                     logits=logits,
                 )
@@ -265,7 +265,7 @@ class FiftyOneLabels(ClassificationSerializer):
                 if self.threshold is not None and confidence < self.threshold:
                     fo_predictions = None
                 else:
-                    fo_predictions = Classification(
+                    fo_predictions = fol.Classification(
                         label=labels[classes],
                         confidence=confidence,
                         logits=logits,
@@ -276,12 +276,12 @@ class FiftyOneLabels(ClassificationSerializer):
             if self.multi_label:
                 classifications = []
                 for idx in classes:
-                    fo_cls = Classification(
+                    fo_cls = fol.Classification(
                         label=str(idx),
                         confidence=probabilities[idx],
                     )
                     classifications.append(fo_cls)
-                fo_predictions = Classifications(
+                fo_predictions = fol.Classifications(
                     classifications=classifications,
                     logits=logits,
                 )
@@ -290,7 +290,7 @@ class FiftyOneLabels(ClassificationSerializer):
                 if self.threshold is not None and confidence < self.threshold:
                     fo_predictions = None
                 else:
-                    fo_predictions = Classification(
+                    fo_predictions = fol.Classification(
                         label=str(classes),
                         confidence=confidence,
                         logits=logits,

--- a/flash/core/classification.py
+++ b/flash/core/classification.py
@@ -26,7 +26,7 @@ from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 Classification, Classifications = None, None
 if _FIFTYONE_AVAILABLE:
     fol = lazy_import("fiftyone.core.labels")
-    from TYPE_CHECKING:
+    if TYPE_CHECKING:
         from fiftyone.core.labels import Classification, Classifications
 else:
     fol = None

--- a/flash/core/classification.py
+++ b/flash/core/classification.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union, TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F
@@ -23,8 +23,11 @@ from flash.core.data.process import Serializer
 from flash.core.model import Task
 from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
+Classification, Classifications = None, None
 if _FIFTYONE_AVAILABLE:
     fol = lazy_import("fiftyone.core.labels")
+    from TYPE_CHECKING:
+        from fiftyone.core.labels import Classification, Classifications
 else:
     fol = None
 
@@ -219,7 +222,7 @@ class FiftyOneLabels(ClassificationSerializer):
     def serialize(
         self,
         sample: Any,
-    ) -> Union[fol.Classification, fol.Classifications, Dict[str, Any], Dict[str, Any]]:
+    ) -> Union[Classification, Classifications, Dict[str, Any], Dict[str, Any]]:
         pred = sample[DefaultDataKeys.PREDS] if isinstance(sample, Dict) else sample
         pred = torch.tensor(pred)
 

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -31,13 +31,12 @@ from flash.core.data.data_pipeline import DataPipeline, DefaultPreprocess, Postp
 from flash.core.data.data_source import DatasetDataSource, DataSource, DefaultDataSources
 from flash.core.data.splits import SplitDataset
 from flash.core.data.utils import _STAGES_PREFIX
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
 if _FIFTYONE_AVAILABLE:
-    import fiftyone as fo
-    from fiftyone.core.collections import SampleCollection
+    foc = lazy_import("fiftyone.core.collections")
 else:
-    SampleCollection = None
+    foc = None
 
 
 class DataModule(pl.LightningDataModule):
@@ -1072,10 +1071,10 @@ class DataModule(pl.LightningDataModule):
     @classmethod
     def from_fiftyone(
         cls,
-        train_dataset: Optional[SampleCollection] = None,
-        val_dataset: Optional[SampleCollection] = None,
-        test_dataset: Optional[SampleCollection] = None,
-        predict_dataset: Optional[SampleCollection] = None,
+        train_dataset: Optional[foc.SampleCollection] = None,
+        val_dataset: Optional[foc.SampleCollection] = None,
+        test_dataset: Optional[foc.SampleCollection] = None,
+        predict_dataset: Optional[foc.SampleCollection] = None,
         train_transform: Optional[Dict[str, Callable]] = None,
         val_transform: Optional[Dict[str, Callable]] = None,
         test_transform: Optional[Dict[str, Callable]] = None,

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -31,7 +31,7 @@ from flash.core.data.data_pipeline import DataPipeline, DefaultPreprocess, Postp
 from flash.core.data.data_source import DataSource, DefaultDataSources
 from flash.core.data.splits import SplitDataset
 from flash.core.data.utils import _STAGES_PREFIX
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
 
 if _FIFTYONE_AVAILABLE and TYPE_CHECKING:
     from fiftyone.core.collections import SampleCollection

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 import platform
-from typing import Any, Callable, Collection, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Collection, Dict, Iterable, List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 import pytorch_lightning as pl
@@ -33,10 +33,10 @@ from flash.core.data.splits import SplitDataset
 from flash.core.data.utils import _STAGES_PREFIX
 from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
-if _FIFTYONE_AVAILABLE:
-    foc = lazy_import("fiftyone.core.collections")
+if _FIFTYONE_AVAILABLE and TYPE_CHECKING:
+    from fiftyone.core.collections import SampleCollection
 else:
-    foc = None
+    SampleCollection = None
 
 
 class DataModule(pl.LightningDataModule):
@@ -1071,10 +1071,10 @@ class DataModule(pl.LightningDataModule):
     @classmethod
     def from_fiftyone(
         cls,
-        train_dataset: Optional[foc.SampleCollection] = None,
-        val_dataset: Optional[foc.SampleCollection] = None,
-        test_dataset: Optional[foc.SampleCollection] = None,
-        predict_dataset: Optional[foc.SampleCollection] = None,
+        train_dataset: Optional[SampleCollection] = None,
+        val_dataset: Optional[SampleCollection] = None,
+        test_dataset: Optional[SampleCollection] = None,
+        predict_dataset: Optional[SampleCollection] = None,
         train_transform: Optional[Dict[str, Callable]] = None,
         val_transform: Optional[Dict[str, Callable]] = None,
         test_transform: Optional[Dict[str, Callable]] = None,

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -27,6 +27,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TYPE_CHECKING,
     TypeVar,
     Union,
 )
@@ -43,11 +44,13 @@ from flash.core.data.properties import ProcessState, Properties
 from flash.core.data.utils import CurrentRunningStageFuncContext
 from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
+SampleCollection = None
 if _FIFTYONE_AVAILABLE:
-    foc = lazy_import("fiftyone.core.collections")
     fol = lazy_import("fiftyone.core.labels")
+    if TYPE_CHECKING:
+        from fiftyone.core.collections import SampleCollection
 else:
-    foc, fol = None, None
+    fol = None
 
 
 # Credit to the PyTorchVision Team:
@@ -474,7 +477,7 @@ class NumpyDataSource(SequenceDataSource[np.ndarray]):
     :meth:`~flash.core.data.data_source.DataSource.load_data` to be a sequence of ``np.ndarray`` objects."""
 
 
-class FiftyOneDataSource(DataSource[foc.SampleCollection]):
+class FiftyOneDataSource(DataSource[SampleCollection]):
     """The ``FiftyOneDataSource`` expects the input to
     :meth:`~flash.core.data.data_source.DataSource.load_data` to be a ``fiftyone.core.collections.SampleCollection``."""
 
@@ -488,7 +491,7 @@ class FiftyOneDataSource(DataSource[foc.SampleCollection]):
     def label_cls(self):
         return fol.Label
 
-    def load_data(self, data: foc.SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
+    def load_data(self, data: SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
         self._validate(data)
 
         label_path = data._get_label_field_path(self.label_field, "label")[1]
@@ -518,7 +521,7 @@ class FiftyOneDataSource(DataSource[foc.SampleCollection]):
         } for f, t in zip(filepaths, targets)]
 
     def predict_load_data(self,
-                          data: foc.SampleCollection,
+                          data: SampleCollection,
                           dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
         return [{DefaultDataKeys.INPUT: f} for f in data.values("filepath")]
 

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -41,13 +41,13 @@ from torch.utils.data.dataset import Dataset
 from flash.core.data.auto_dataset import AutoDataset, BaseAutoDataset, IterableAutoDataset
 from flash.core.data.properties import ProcessState, Properties
 from flash.core.data.utils import CurrentRunningStageFuncContext
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
 if _FIFTYONE_AVAILABLE:
-    from fiftyone.core.collections import SampleCollection
-    from fiftyone.core.labels import Label
+    foc = lazy_import("fiftyone.core.collections")
+    fol = lazy_import("fiftyone.core.labels")
 else:
-    Label, SampleCollection = None, None
+    foc, fol = None, None
 
 
 # Credit to the PyTorchVision Team:
@@ -474,7 +474,7 @@ class NumpyDataSource(SequenceDataSource[np.ndarray]):
     :meth:`~flash.core.data.data_source.DataSource.load_data` to be a sequence of ``np.ndarray`` objects."""
 
 
-class FiftyOneDataSource(DataSource[SampleCollection]):
+class FiftyOneDataSource(DataSource[foc.SampleCollection]):
     """The ``FiftyOneDataSource`` expects the input to
     :meth:`~flash.core.data.data_source.DataSource.load_data` to be a ``fiftyone.core.collections.SampleCollection``."""
 
@@ -486,9 +486,9 @@ class FiftyOneDataSource(DataSource[SampleCollection]):
 
     @property
     def label_cls(self):
-        return Label
+        return fol.Label
 
-    def load_data(self, data: SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
+    def load_data(self, data: foc.SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
         self._validate(data)
 
         label_path = data._get_label_field_path(self.label_field, "label")[1]
@@ -517,7 +517,9 @@ class FiftyOneDataSource(DataSource[SampleCollection]):
             DefaultDataKeys.TARGET: to_idx(t),
         } for f, t in zip(filepaths, targets)]
 
-    def predict_load_data(self, data: SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
+    def predict_load_data(self,
+                          data: foc.SampleCollection,
+                          dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
         return [{DefaultDataKeys.INPUT: f} for f in data.values("filepath")]
 
     def _validate(self, data):

--- a/flash/core/integrations/fiftyone/utils.py
+++ b/flash/core/integrations/fiftyone/utils.py
@@ -2,7 +2,7 @@ from itertools import chain
 from typing import Dict, List, Optional, Union, TYPE_CHECKING
 
 import flash
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
 Label, Session = None, None
 if _FIFTYONE_AVAILABLE:

--- a/flash/core/integrations/fiftyone/utils.py
+++ b/flash/core/integrations/fiftyone/utils.py
@@ -3,29 +3,21 @@ from typing import Dict, List, Optional, Union
 
 import flash
 from flash.core.data.data_source import DefaultDataKeys
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
 if _FIFTYONE_AVAILABLE:
-    import fiftyone as fo
-    from fiftyone.core.labels import Label
-    from fiftyone.core.sample import Sample
-    from fiftyone.core.session import Session
-    from fiftyone.utils.data.parsers import LabeledImageTupleSampleParser
+    fo = lazy_import("fiftyone")
 else:
     fo = None
-    SampleCollection = None
-    Label = None
-    Sample = None
-    Session = None
 
 
 def visualize(
-    predictions: Union[List[Label], List[Dict[str, Label]]],
+    predictions: Union[List[fo.Label], List[Dict[str, fo.Label]]],
     filepaths: Optional[List[str]] = None,
     label_field: Optional[str] = "predictions",
     wait: Optional[bool] = False,
     **kwargs
-) -> Optional[Session]:
+) -> Optional[fo.Session]:
     """Visualizes predictions from a model with a FiftyOne Serializer in the
     :ref:`FiftyOne App <fiftyone:fiftyone-app>`.
 

--- a/flash/core/integrations/fiftyone/utils.py
+++ b/flash/core/integrations/fiftyone/utils.py
@@ -1,23 +1,26 @@
 from itertools import chain
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, TYPE_CHECKING
 
 import flash
 from flash.core.data.data_source import DefaultDataKeys
 from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
+Label, Session = None, None
 if _FIFTYONE_AVAILABLE:
     fo = lazy_import("fiftyone")
+    if TYPE_CHECKING:
+        from fiftyone import Label, Session
 else:
     fo = None
 
 
 def visualize(
-    predictions: Union[List[fo.Label], List[Dict[str, fo.Label]]],
+    predictions: Union[List[Label], List[Dict[str, Label]]],
     filepaths: Optional[List[str]] = None,
     label_field: Optional[str] = "predictions",
     wait: Optional[bool] = False,
     **kwargs
-) -> Optional[fo.Session]:
+) -> Optional[Session]:
     """Visualizes predictions from a model with a FiftyOne Serializer in the
     :ref:`FiftyOne App <fiftyone:fiftyone-app>`.
 

--- a/flash/core/utilities/imports.py
+++ b/flash/core/utilities/imports.py
@@ -15,6 +15,7 @@
 import functools
 import importlib
 import operator
+import types
 from importlib.util import find_spec
 
 from pkg_resources import DistributionNotFound
@@ -126,3 +127,69 @@ def _requires_extras(extras: str):
         return wrapper
 
     return decorator
+
+
+def lazy_import(module_name, callback=None):
+    """Returns a proxy module object that will lazily import the given module
+    the first time it is used.
+
+    Example usage::
+
+        # Lazy version of `import tensorflow as tf`
+        tf = lazy_import("tensorflow")
+
+        # Other commands
+
+        # Now the module is loaded
+        tf.__version__
+
+    Args:
+        module_name: the fully-qualified module name to import
+        callback (None): a callback function to call before importing the
+            module
+
+    Returns:
+        a proxy module object that will be lazily imported when first used
+    """
+    return LazyModule(module_name, callback=callback)
+
+
+class LazyModule(types.ModuleType):
+    """Proxy module that lazily imports the underlying module the first time it
+    is actually used.
+
+    Args:
+        module_name: the fully-qualified module name to import
+        callback (None): a callback function to call before importing the
+            module
+    """
+
+    def __init__(self, module_name, callback=None):
+        super().__init__(module_name)
+        self._module = None
+        self._callback = callback
+
+    def __getattr__(self, item):
+        if self._module is None:
+            self._import_module()
+
+        return getattr(self._module, item)
+
+    def __dir__(self):
+        if self._module is None:
+            self._import_module()
+
+        return dir(self._module)
+
+    def _import_module(self):
+        # Execute callback, if any
+        if self._callback is not None:
+            self._callback()
+
+        # Actually import the module
+        module = importlib.import_module(self.__name__)
+        self._module = module
+
+        # Update this object's dict so that attribute references are efficient
+        # (__getattr__ is only called on lookups that fail)
+        self.__dict__.update(module.__dict__)

--- a/flash/image/detection/data.py
+++ b/flash/image/detection/data.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, TYPE_CHECKING
 
 from flash.core.data.callback import BaseDataFetcher
 from flash.core.data.data_module import DataModule
@@ -30,9 +30,11 @@ from flash.image.detection.transforms import default_transforms
 if _COCO_AVAILABLE:
     from pycocotools.coco import COCO
 
+SampleCollection = None
 if _FIFTYONE_AVAILABLE:
-    foc = lazy_import("fiftyone.core.collections")
     fol = lazy_import("fiftyone.core.labels")
+    if TYPE_CHECKING:
+        from fiftyone.core.collections import SampleCollection
 else:
     foc, fol = None, None
 
@@ -119,7 +121,7 @@ class ObjectDetectionFiftyOneDataSource(FiftyOneDataSource):
     def label_cls(self):
         return fol.Detections
 
-    def load_data(self, data: foc.SampleCollection, dataset: Optional[Any] = None) -> Sequence[Dict[str, Any]]:
+    def load_data(self, data: SampleCollection, dataset: Optional[Any] = None) -> Sequence[Dict[str, Any]]:
         self._validate(data)
 
         data.compute_metadata()

--- a/flash/image/detection/data.py
+++ b/flash/image/detection/data.py
@@ -18,7 +18,12 @@ from flash.core.data.callback import BaseDataFetcher
 from flash.core.data.data_module import DataModule
 from flash.core.data.data_source import DataSource, DefaultDataKeys, DefaultDataSources, FiftyOneDataSource
 from flash.core.data.process import Preprocess, Serializer
-from flash.core.utilities.imports import _COCO_AVAILABLE, _FIFTYONE_AVAILABLE, _TORCHVISION_AVAILABLE
+from flash.core.utilities.imports import (
+    _COCO_AVAILABLE,
+    _FIFTYONE_AVAILABLE,
+    _TORCHVISION_AVAILABLE,
+    lazy_import,
+)
 from flash.image.data import ImagePathsDataSource
 from flash.image.detection.transforms import default_transforms
 
@@ -26,10 +31,10 @@ if _COCO_AVAILABLE:
     from pycocotools.coco import COCO
 
 if _FIFTYONE_AVAILABLE:
-    from fiftyone.core.collections import SampleCollection
-    from fiftyone.core.labels import Detections
+    foc = lazy_import("fiftyone.core.collections")
+    fol = lazy_import("fiftyone.core.labels")
 else:
-    Detections, SampleCollection = None, None
+    foc, fol = None, None
 
 if _TORCHVISION_AVAILABLE:
     from torchvision.datasets.folder import default_loader
@@ -112,9 +117,9 @@ class ObjectDetectionFiftyOneDataSource(FiftyOneDataSource):
 
     @property
     def label_cls(self):
-        return Detections
+        return fol.Detections
 
-    def load_data(self, data: SampleCollection, dataset: Optional[Any] = None) -> Sequence[Dict[str, Any]]:
+    def load_data(self, data: foc.SampleCollection, dataset: Optional[Any] = None) -> Sequence[Dict[str, Any]]:
         self._validate(data)
 
         data.compute_metadata()

--- a/flash/image/detection/serialization.py
+++ b/flash/image/detection/serialization.py
@@ -17,12 +17,12 @@ from pytorch_lightning.utilities import rank_zero_warn
 
 from flash.core.data.data_source import DefaultDataKeys, LabelsState
 from flash.core.data.process import Serializer
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
 if _FIFTYONE_AVAILABLE:
-    from fiftyone.core.labels import Detection, Detections
+    fo = lazy_import("fiftyone")
 else:
-    Detection, Detections = None, None
+    fo = None
 
 
 class DetectionLabels(Serializer):
@@ -62,7 +62,7 @@ class FiftyOneDetectionLabels(Serializer):
         if labels is not None:
             self.set_state(LabelsState(labels))
 
-    def serialize(self, sample: Dict[str, Any]) -> Union[Detections, Dict[str, Any]]:
+    def serialize(self, sample: Dict[str, Any]) -> Union[fo.Detections, Dict[str, Any]]:
         if DefaultDataKeys.METADATA not in sample:
             raise ValueError("sample requires DefaultDataKeys.METADATA to use a FiftyOneDetectionLabels serializer.")
 
@@ -100,12 +100,12 @@ class FiftyOneDetectionLabels(Serializer):
             else:
                 label = str(int(label))
 
-            detections.append(Detection(
+            detections.append(fo.Detection(
                 label=label,
                 bounding_box=box,
                 confidence=confidence,
             ))
-        fo_predictions = Detections(detections=detections)
+        fo_predictions = fo.Detections(detections=detections)
         if self.return_filepath:
             filepath = sample[DefaultDataKeys.METADATA]["filepath"]
             return {"filepath": filepath, "predictions": fo_predictions}

--- a/flash/image/detection/serialization.py
+++ b/flash/image/detection/serialization.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 from pytorch_lightning.utilities import rank_zero_warn
 
@@ -19,8 +19,11 @@ from flash.core.data.data_source import DefaultDataKeys, LabelsState
 from flash.core.data.process import Serializer
 from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import
 
+Detections = None
 if _FIFTYONE_AVAILABLE:
     fo = lazy_import("fiftyone")
+    if TYPE_CHECKING:
+        from fiftyone import Detections
 else:
     fo = None
 
@@ -62,7 +65,7 @@ class FiftyOneDetectionLabels(Serializer):
         if labels is not None:
             self.set_state(LabelsState(labels))
 
-    def serialize(self, sample: Dict[str, Any]) -> Union[fo.Detections, Dict[str, Any]]:
+    def serialize(self, sample: Dict[str, Any]) -> Union[Detections, Dict[str, Any]]:
         if DefaultDataKeys.METADATA not in sample:
             raise ValueError("sample requires DefaultDataKeys.METADATA to use a FiftyOneDetectionLabels serializer.")
 

--- a/flash/image/segmentation/data.py
+++ b/flash/image/segmentation/data.py
@@ -42,17 +42,17 @@ from flash.core.utilities.imports import (
     _PIL_AVAILABLE,
     _requires_extras,
     _TORCHVISION_AVAILABLE,
+    lazy_import,
 )
 from flash.image.data import ImageDeserializer
 from flash.image.segmentation.serialization import SegmentationLabels
 from flash.image.segmentation.transforms import default_transforms, train_default_transforms
 
 if _FIFTYONE_AVAILABLE:
-    import fiftyone as fo
-    from fiftyone.core.collections import SampleCollection
-    from fiftyone.core.labels import Segmentation
+    fo = lazy_import("fiftyone")
+    foc = lazy_import("fiftyone.core.collections")
 else:
-    fo, Segmentation, SampleCollection = None, None, None
+    fo, foc = None, None
 
 if _MATPLOTLIB_AVAILABLE:
     import matplotlib.pyplot as plt
@@ -181,9 +181,9 @@ class SemanticSegmentationFiftyOneDataSource(FiftyOneDataSource):
 
     @property
     def label_cls(self):
-        return Segmentation
+        return fo.Segmentation
 
-    def load_data(self, data: SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
+    def load_data(self, data: foc.SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
         self._validate(data)
 
         self._fo_dataset_name = data.name

--- a/flash/image/segmentation/data.py
+++ b/flash/image/segmentation/data.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -48,11 +48,13 @@ from flash.image.data import ImageDeserializer
 from flash.image.segmentation.serialization import SegmentationLabels
 from flash.image.segmentation.transforms import default_transforms, train_default_transforms
 
+SampleCollection = None
 if _FIFTYONE_AVAILABLE:
     fo = lazy_import("fiftyone")
-    foc = lazy_import("fiftyone.core.collections")
+    if TYPE_CHECKING:
+        from fiftyone.core.collections import SampleCollection
 else:
-    fo, foc = None, None
+    fo = None
 
 if _MATPLOTLIB_AVAILABLE:
     import matplotlib.pyplot as plt
@@ -183,7 +185,7 @@ class SemanticSegmentationFiftyOneDataSource(FiftyOneDataSource):
     def label_cls(self):
         return fo.Segmentation
 
-    def load_data(self, data: foc.SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
+    def load_data(self, data: SampleCollection, dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
         self._validate(data)
 
         self._fo_dataset_name = data.name

--- a/flash/image/segmentation/serialization.py
+++ b/flash/image/segmentation/serialization.py
@@ -20,12 +20,17 @@ import torch
 import flash
 from flash.core.data.data_source import DefaultDataKeys, ImageLabelsMap
 from flash.core.data.process import Serializer
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, _KORNIA_AVAILABLE, _MATPLOTLIB_AVAILABLE
+from flash.core.utilities.imports import (
+    _FIFTYONE_AVAILABLE,
+    _KORNIA_AVAILABLE,
+    _MATPLOTLIB_AVAILABLE,
+    lazy_import,
+)
 
 if _FIFTYONE_AVAILABLE:
-    from fiftyone.core.labels import Segmentation
+    fol = lazy_import("fiftyone.core.labels")
 else:
-    Segmentation = None
+    fol = None
 
 if _MATPLOTLIB_AVAILABLE:
     import matplotlib.pyplot as plt
@@ -114,9 +119,9 @@ class FiftyOneSegmentationLabels(SegmentationLabels):
 
         self.return_filepath = return_filepath
 
-    def serialize(self, sample: Dict[str, torch.Tensor]) -> Union[Segmentation, Dict[str, Any]]:
+    def serialize(self, sample: Dict[str, torch.Tensor]) -> Union[fol.Segmentation, Dict[str, Any]]:
         labels = super().serialize(sample)
-        fo_predictions = Segmentation(mask=np.array(labels))
+        fo_predictions = fol.Segmentation(mask=np.array(labels))
         if self.return_filepath:
             filepath = sample[DefaultDataKeys.METADATA]["filepath"]
             return {"filepath": filepath, "predictions": fo_predictions}

--- a/flash/image/segmentation/serialization.py
+++ b/flash/image/segmentation/serialization.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -27,8 +27,11 @@ from flash.core.utilities.imports import (
     lazy_import,
 )
 
+Segmentation = None
 if _FIFTYONE_AVAILABLE:
     fol = lazy_import("fiftyone.core.labels")
+    if TYPE_CHECKING:
+        from fiftyone.core.labels import Segmentation
 else:
     fol = None
 
@@ -119,7 +122,7 @@ class FiftyOneSegmentationLabels(SegmentationLabels):
 
         self.return_filepath = return_filepath
 
-    def serialize(self, sample: Dict[str, torch.Tensor]) -> Union[fol.Segmentation, Dict[str, Any]]:
+    def serialize(self, sample: Dict[str, torch.Tensor]) -> Union[Segmentation, Dict[str, Any]]:
         labels = super().serialize(sample)
         fo_predictions = fol.Segmentation(mask=np.array(labels))
         if self.return_filepath:

--- a/flash/video/classification/data.py
+++ b/flash/video/classification/data.py
@@ -29,13 +29,18 @@ from flash.core.data.data_source import (
 )
 from flash.core.data.process import Preprocess
 from flash.core.data.transforms import merge_transforms
-from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, _KORNIA_AVAILABLE, _PYTORCHVIDEO_AVAILABLE
+from flash.core.utilities.imports import (
+    _FIFTYONE_AVAILABLE,
+    _KORNIA_AVAILABLE,
+    _PYTORCHVIDEO_AVAILABLE,
+    lazy_import,
+)
 
 if _FIFTYONE_AVAILABLE:
-    from fiftyone.core.collections import SampleCollection
-    from fiftyone.core.labels import Classification
+    foc = lazy_import("fiftyone.core.collections")
+    fol = lazy_import("fiftyone.core.labels")
 else:
-    Classification, SampleCollection = None, None
+    foc, fol = None, None
 
 if _KORNIA_AVAILABLE:
     import kornia.augmentation as K
@@ -180,9 +185,9 @@ class VideoClassificationFiftyOneDataSource(
 
     @property
     def label_cls(self):
-        return Classification
+        return fol.Classification
 
-    def _make_encoded_video_dataset(self, data: SampleCollection) -> 'EncodedVideoDataset':
+    def _make_encoded_video_dataset(self, data: foc.SampleCollection) -> 'EncodedVideoDataset':
         classes = self._get_classes(data)
         label_to_class_mapping = dict(enumerate(classes))
         class_to_label_mapping = {c: lab for lab, c in label_to_class_mapping.items()}

--- a/flash/video/classification/data.py
+++ b/flash/video/classification/data.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pathlib
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union, TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -36,11 +36,13 @@ from flash.core.utilities.imports import (
     lazy_import,
 )
 
+SampleCollection = None
 if _FIFTYONE_AVAILABLE:
-    foc = lazy_import("fiftyone.core.collections")
     fol = lazy_import("fiftyone.core.labels")
+    if TYPE_CHECKING:
+        from fiftyone.core.collections import SampleCollection
 else:
-    foc, fol = None, None
+    fol = None
 
 if _KORNIA_AVAILABLE:
     import kornia.augmentation as K
@@ -187,7 +189,7 @@ class VideoClassificationFiftyOneDataSource(
     def label_cls(self):
         return fol.Classification
 
-    def _make_encoded_video_dataset(self, data: foc.SampleCollection) -> 'EncodedVideoDataset':
+    def _make_encoded_video_dataset(self, data: SampleCollection) -> 'EncodedVideoDataset':
         classes = self._get_classes(data)
         label_to_class_mapping = dict(enumerate(classes))
         class_to_label_mapping = {c: lab for lab, c in label_to_class_mapping.items()}


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to lazily import modules so that they are not actually imported until their first reference. This is applied to all `fiftyone` imports to avoid spinning up the FiftyOne database service if it is not being used.


## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [X] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [X] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
