### PR TITLE
update pystiche dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,9 +446,9 @@ python flash_examples/finetuning/semantic_segmentation.py
 
 </details>
 
-### Example 7: Style Transfer with Pystiche
+### Example 7: Style Transfer with pystiche
 
-Flash has a [Style Transfer task](https://lightning-flash.readthedocs.io/en/latest/reference/style_transfer.html) for Neural Style Transfer (NST) with [Pystiche](https://github.com/pystiche/pystiche).
+Flash has a [Style Transfer task](https://lightning-flash.readthedocs.io/en/latest/reference/style_transfer.html) for Neural Style Transfer (NST) with [pystiche](https://pystiche.org).
 
 <details>
   <summary>View example</summary>

--- a/docs/source/reference/style_transfer.rst
+++ b/docs/source/reference/style_transfer.rst
@@ -12,7 +12,7 @@ The Task
 The Neural Style Transfer Task is an optimization method which extract the style from an image and apply it another image while preserving its content.
 The goal is that the output image looks like the content image, but “painted” in the style of the style reference image.
 
-.. image:: https://raw.githubusercontent.com/pystiche/pystiche/master/docs/source/graphics/banner/banner.jpg
+.. image:: https://raw.githubusercontent.com/pystiche/pystiche/main/docs/source/graphics/banner/banner.jpg
     :alt: style_transfer_example
 
 The :class:`~flash.image.style_transfer.model.StyleTransfer` and :class:`~flash.image.style_transfer.data.StyleTransferData` classes internally rely on `pystiche <https://pystiche.org>`_.

--- a/flash/image/style_transfer/model.py
+++ b/flash/image/style_transfer/model.py
@@ -34,12 +34,10 @@ else:
         Encoder = None
         MultiLayerEncoder = None
 
-    class ops:
-        EncodingComparisonOperator = None
-        FeatureReconstructionOperator = None
-        MultiLayerEncodingOperator = None
-
     class loss:
+        class GramLoss:
+            pass
+
         class PerceptualLoss:
             pass
 

--- a/flash/image/style_transfer/model.py
+++ b/flash/image/style_transfer/model.py
@@ -150,9 +150,7 @@ class StyleTransfer(Task):
         style_weight: float,
     ) -> loss.PerceptualLoss:
         mle, _ = cast(enc.MultiLayerEncoder, self.backbones.get(backbone)())
-        content_loss = loss.FeatureReconstructionLoss(
-            mle.extract_encoder(content_layer), score_weight=content_weight
-        )
+        content_loss = loss.FeatureReconstructionLoss(mle.extract_encoder(content_layer), score_weight=content_weight)
         style_loss = loss.MultiLayerEncodingLoss(
             mle,
             style_layers,

--- a/requirements/datatype_image.txt
+++ b/requirements/datatype_image.txt
@@ -3,5 +3,5 @@ timm>=0.4.5
 lightning-bolts>=0.3.3
 Pillow>=7.2
 kornia>=0.5.1,<0.5.4
-pystiche>=0.7.2
+pystiche==1.*
 segmentation-models-pytorch

--- a/tests/image/style_transfer/test_model.py
+++ b/tests/image/style_transfer/test_model.py
@@ -49,6 +49,9 @@ def test_jit(tmpdir):
     model = StyleTransfer()
     model.eval()
 
+    model.loss_fn = None
+    model.perceptual_loss = None  # TODO: Document this
+
     model = torch.jit.trace(model, torch.rand(1, 3, 32, 32))  # torch.jit.script doesn't work with pystiche
 
     torch.jit.save(model, path)


### PR DESCRIPTION
## What does this PR do?

This upgrades a couple of things regarding the `pystiche` dependency:

- `pystiche==1.0.0` was released and now follows semantic versioning. Thus, It is reasonable to pin it to the current stable release.
- `pystiche.ops` is deprecated in favor of `pystiche.loss`. Although everything should work as expected as is, without change the code will now emit deprecation warnings. All occurrences of `pystiche.ops` were replaced.
- `pystiche`'s default branch was changed from `master` to `main`. A link was updated to reflect this.
- `pystiche` should be written with a lower `p`. All occurrences in the documentation that did not do this were updated.

Fixes # (issue)

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
