### PR TITLE
Remove embedding_dim parameter in ImageEmbedder examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ from flash.image import ImageEmbedder
 download_data("https://pl-flash-data.s3.amazonaws.com/hymenoptera_data.zip", "data/")
 
 # 2. Create an ImageEmbedder with resnet50 trained on imagenet.
-embedder = ImageEmbedder(backbone="resnet50", embedding_dim=128)
+embedder = ImageEmbedder(backbone="resnet50")
 
 # 3. Generate an embedding from an image path.
 embeddings = embedder.predict("data/hymenoptera_data/predict/153783656_85f9c3ac70.jpg")

--- a/flash_examples/integrations/fiftyone/image_embedding.py
+++ b/flash_examples/integrations/fiftyone/image_embedding.py
@@ -28,7 +28,7 @@ dataset = fo.Dataset.from_dir(
 )
 
 # 3 Load model
-embedder = ImageEmbedder(backbone="resnet101", embedding_dim=128)
+embedder = ImageEmbedder(backbone="resnet101")
 
 # 4 Generate embeddings
 filepaths = dataset.values("filepath")


### PR DESCRIPTION
## What does this PR do?

### What
* Removed `embedding_dim` parameter in the ImageEmbedder README example
* Removed `embedding_dim` parameter in the ImageEmbedder code example
* Searched for all other references to `embedding_dim` usgae -- Only other one is in a unit test, which should stay

### Why
* Reference: #653 
* According to code warning, `embedding_dim` should only be used if the user fine-tunes after. That is not done in these examples, and probably shouldn't anyway since that's a bit out of scope for the simple example.

Fixes # (issue)

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements) -- #653 
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
