### PR TITLE
Add parsing of kwargs to request dataloaders + test

### DIFF
--- a/flash/core/trainer.py
+++ b/flash/core/trainer.py
@@ -15,7 +15,7 @@ import inspect
 import warnings
 from argparse import ArgumentParser, Namespace
 from functools import wraps
-from typing import Callable, List, Optional, Union, Dict, Tuple
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from pytorch_lightning import LightningDataModule, LightningModule
@@ -221,9 +221,8 @@ class Trainer(PlTrainer):
         # context: https://github.com/PyTorchLightning/lightning-flash/issues/342#issuecomment-848892447
         return from_argparse_args(Trainer, args, **kwargs)
 
-    def _parse_request_dataloader_args(self, args : Tuple, kwargs: Dict):
-        """
-        Handles backwards compatibility for ``request_dataloader``.
+    def _parse_request_dataloader_args(self, args: Tuple, kwargs: Dict):
+        """Handles backwards compatibility for ``request_dataloader``.
 
         Possible combinations:
 
@@ -237,11 +236,11 @@ class Trainer(PlTrainer):
             if isinstance(args[0], LightningModule):
                 is_legacy = True
                 model, stage = args
-            else: # (stage, model)
+            else:  # (stage, model)
                 stage, model = args
         else:
-             stage = kwargs["stage"] if "stage" in kwargs else args[0]
-             model = kwargs.get("model")
+            stage = kwargs["stage"] if "stage" in kwargs else args[0]
+            model = kwargs.get("model")
         return model, stage, is_legacy
 
     def request_dataloader(

--- a/flash/core/trainer.py
+++ b/flash/core/trainer.py
@@ -15,7 +15,7 @@ import inspect
 import warnings
 from argparse import ArgumentParser, Namespace
 from functools import wraps
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Union, Dict, Tuple
 
 import torch
 from pytorch_lightning import LightningDataModule, LightningModule
@@ -221,21 +221,44 @@ class Trainer(PlTrainer):
         # context: https://github.com/PyTorchLightning/lightning-flash/issues/342#issuecomment-848892447
         return from_argparse_args(Trainer, args, **kwargs)
 
+    def _parse_request_dataloader_args(self, args : Tuple, kwargs: Dict):
+        """
+        Handles backwards compatibility for ``request_dataloader``.
+
+        Possible combinations:
+
+        legacy: (model, stage)
+        (stage, model)
+        (stage, model=model)
+        """
+        model, stage, is_legacy = None, None, False
+        if len(args) == 2:
+            # Check for legacy arguments: (model, stage)
+            if isinstance(args[0], LightningModule):
+                is_legacy = True
+                model, stage = args
+            else: # (stage, model)
+                stage, model = args
+        else:
+             stage = kwargs["stage"] if "stage" in kwargs else args[0]
+             model = kwargs.get("model")
+        return model, stage, is_legacy
+
     def request_dataloader(
         self,
         *args,
+        **kwargs,
     ) -> Union[DataLoader, List[DataLoader]]:
         """Handles downloading data in the GPU or TPU case.
 
         Returns:
             The dataloader
         """
-        if isinstance(args[0], LightningModule):
-            model, stage = args
+        model, stage, is_legacy = self._parse_request_dataloader_args(args, kwargs)
+        if is_legacy:
             self.call_hook(f"on_{stage}_dataloader")
             dataloader = getattr(model, f"{stage}_dataloader")()
         else:
-            stage, model = args
             hook = f"{stage.dataloader_prefix}_dataloader"
             self.call_hook("on_" + hook, pl_module=model)
             dataloader = self.call_hook(hook, pl_module=model)

--- a/flash/core/trainer.py
+++ b/flash/core/trainer.py
@@ -239,7 +239,7 @@ class Trainer(PlTrainer):
             else:  # (stage, model)
                 stage, model = args
         else:
-            stage = kwargs["stage"] if "stage" in kwargs else args[0]
+            stage = kwargs.get("stage", args[0])
             model = kwargs.get("model")
         return model, stage, is_legacy
 

--- a/tests/core/test_trainer.py
+++ b/tests/core/test_trainer.py
@@ -156,9 +156,10 @@ def test_trainer_request_dataloaders_legacy(stage):
     assert trainer.recorded_on_dataloader_calls[stage]
 
 
+@pytest.mark.skip(reason="TODO: test can only be enabled once Lightning 1.5 is released.")
 @pytest.mark.parametrize("stage", [RunningStage.TRAINING, RunningStage.VALIDATING, RunningStage.TESTING])
 def test_trainer_request_dataloaders(stage):
-    """Test to ensure that ``request_dataloaders`` can take a combination of arguments, to new PL versions.
+    """Test to ensure that ``request_dataloaders`` can take a combination of arguments, for PL 1.5 and later.
 
     (stage, model) -> calls module on_dataloader hook (stage, model=model) -> calls module on_dataloader hook
     """

--- a/tests/core/test_trainer.py
+++ b/tests/core/test_trainer.py
@@ -126,7 +126,7 @@ def test_from_argparse_args():
     assert isinstance(trainer, Trainer)
 
 
-@pytest.mark.parametrize("stage", [RunningStage.TRAINING, RunningStage.VALIDATING, RunningStage.TESTING])
+@pytest.mark.parametrize("stage", ["train", "val", "test"])
 def test_trainer_request_dataloaders_legacy(stage):
     """Test to ensure that ``request_dataloaders`` can take the legacy PL ordering of arguments.
 
@@ -137,13 +137,13 @@ def test_trainer_request_dataloaders_legacy(stage):
         recorded_on_dataloader_calls = {}
 
         def on_train_dataloader(self) -> None:
-            self.recorded_on_dataloader_calls[RunningStage.TRAINING] = True
+            self.recorded_on_dataloader_calls["train"] = True
 
         def on_val_dataloader(self) -> None:
-            self.recorded_on_dataloader_calls[RunningStage.VALIDATING] = True
+            self.recorded_on_dataloader_calls["val"] = True
 
         def on_test_dataloader(self) -> None:
-            self.recorded_on_dataloader_calls[RunningStage.TESTING] = True
+            self.recorded_on_dataloader_calls["test"] = True
 
     model = BoringModel()
     trainer = TestTrainer()

--- a/tests/core/test_trainer.py
+++ b/tests/core/test_trainer.py
@@ -148,11 +148,7 @@ def test_trainer_request_dataloaders_legacy(stage):
     model = BoringModel()
     trainer = TestTrainer()
 
-    trainer.request_dataloader(stage, model)
-    assert trainer.recorded_on_dataloader_calls[stage]
-
-    trainer = TestTrainer()
-    trainer.request_dataloader(stage, model=model)
+    trainer.request_dataloader(model, stage)
     assert trainer.recorded_on_dataloader_calls[stage]
 
 

--- a/tests/core/test_trainer.py
+++ b/tests/core/test_trainer.py
@@ -19,13 +19,13 @@ import torch
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.trainer.states import RunningStage
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from tests.helpers.boring_model import BoringModel
 from torch import nn
 from torch.nn import functional as F
 
 from flash import Trainer
 from flash.core.classification import ClassificationTask
 from flash.core.finetuning import NoFreeze
+from tests.helpers.boring_model import BoringModel
 
 
 class DummyDataset(torch.utils.data.Dataset):
@@ -125,13 +125,14 @@ def test_from_argparse_args():
     assert trainer.max_epochs == 200
     assert isinstance(trainer, Trainer)
 
+
 @pytest.mark.parametrize("stage", [RunningStage.TRAINING, RunningStage.VALIDATING, RunningStage.TESTING])
 def test_trainer_request_dataloaders_legacy(stage):
-    """
-    Test to ensure that ``request_dataloaders`` can take the legacy PL ordering of arguments
+    """Test to ensure that ``request_dataloaders`` can take the legacy PL ordering of arguments.
 
     legacy: (model, stage)
     """
+
     class TestTrainer(Trainer):
         recorded_on_dataloader_calls = {}
 
@@ -157,11 +158,9 @@ def test_trainer_request_dataloaders_legacy(stage):
 
 @pytest.mark.parametrize("stage", [RunningStage.TRAINING, RunningStage.VALIDATING, RunningStage.TESTING])
 def test_trainer_request_dataloaders(stage):
-    """
-    Test to ensure that ``request_dataloaders`` can take a combination of arguments, to new PL versions
+    """Test to ensure that ``request_dataloaders`` can take a combination of arguments, to new PL versions.
 
-    (stage, model) -> calls module on_dataloader hook
-    (stage, model=model) -> calls module on_dataloader hook
+    (stage, model) -> calls module on_dataloader hook (stage, model=model) -> calls module on_dataloader hook
     """
 
     class TestModel(BoringModel):


### PR DESCRIPTION
## What does this PR do?

Fixes an error I was running into use Lightning Master:

```
  File "flash_examples/object_detection.py", line 34, in <module>
    trainer.finetune(model, datamodule=datamodule, strategy="freeze")
  File "/home/sean/lightning-flash/flash/core/trainer.py", line 174, in finetune
    return super().fit(model, train_dataloader, val_dataloaders, datamodule)
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/trainer.py", line 552, in fit
    self._call_and_handle_interrupt(self._fit_impl, model, train_dataloaders, val_dataloaders, datamodule)
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/trainer.py", line 507, in _call_and_handle_interrupt
    return trainer_fn(*args, **kwargs)
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/trainer.py", line 582, in _fit_impl
    self._run(model)
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/trainer.py", line 1006, in _run
    self._dispatch()
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/trainer.py", line 1077, in _dispatch
    self.accelerator.start_training(self)
  File "/home/sean/pytorch-lightning/pytorch_lightning/accelerators/accelerator.py", line 91, in start_training
    self.training_type_plugin.start_training(trainer)
  File "/home/sean/pytorch-lightning/pytorch_lightning/plugins/training_type/training_type_plugin.py", line 170, in start_training
    self._results = trainer.run_stage()
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/trainer.py", line 1087, in run_stage
    return self._run_train()
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/trainer.py", line 1116, in _run_train
    self._run_sanity_check(self.lightning_module)
  File "/home/sean/lightning-flash/flash/core/trainer.py", line 102, in _run_sanity_check
    super()._run_sanity_check(ref_model)
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/trainer.py", line 1174, in _run_sanity_check
    self._evaluation_loop.reload_evaluation_dataloaders()
  File "/home/sean/pytorch-lightning/pytorch_lightning/loops/dataloader/evaluation_loop.py", line 164, in reload_evaluation_dataloaders
    self.trainer.reset_val_dataloader()
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/data_loading.py", line 472, in reset_val_dataloader
    self.num_val_batches, self.val_dataloaders = self._reset_eval_dataloader(
  File "/home/sean/pytorch-lightning/pytorch_lightning/trainer/data_loading.py", line 385, in _reset_eval_dataloader
    dataloaders = self.request_dataloader(mode, model=model)
TypeError: request_dataloader() got an unexpected keyword argument 'model'
```

Might not be the cleanest solution, but seems to work!

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
