### PR TITLE
enable persistent workers for train and val dataloaders

### DIFF
--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -288,6 +288,7 @@ class DataModule(pl.LightningDataModule):
         else:
             drop_last = len(train_ds) > self.batch_size
         pin_memory = True
+        persistent_workers = True
 
         if self.sampler is None:
             sampler = None
@@ -323,6 +324,7 @@ class DataModule(pl.LightningDataModule):
         val_ds: Dataset = self._val_ds() if isinstance(self._val_ds, Callable) else self._val_ds
         collate_fn = self._resolve_collate_fn(val_ds, RunningStage.VALIDATING)
         pin_memory = True
+        persistent_workers = True
 
         if isinstance(getattr(self, "trainer", None), pl.Trainer):
             return self.trainer.lightning_module.process_val_dataset(
@@ -340,12 +342,14 @@ class DataModule(pl.LightningDataModule):
             num_workers=self.num_workers,
             pin_memory=pin_memory,
             collate_fn=collate_fn,
+            persistent_workers=persistent_workers,
         )
 
     def _test_dataloader(self) -> DataLoader:
         test_ds: Dataset = self._test_ds() if isinstance(self._test_ds, Callable) else self._test_ds
         collate_fn = self._resolve_collate_fn(test_ds, RunningStage.TESTING)
         pin_memory = True
+        persistent_workers = False
 
         if isinstance(getattr(self, "trainer", None), pl.Trainer):
             return self.trainer.lightning_module.process_test_dataset(
@@ -355,6 +359,7 @@ class DataModule(pl.LightningDataModule):
                 num_workers=self.num_workers,
                 pin_memory=pin_memory,
                 collate_fn=collate_fn,
+                persistent_workers=persistent_workers,
             )
 
         return DataLoader(
@@ -363,6 +368,7 @@ class DataModule(pl.LightningDataModule):
             num_workers=self.num_workers,
             pin_memory=pin_memory,
             collate_fn=collate_fn,
+            persistent_workers=persistent_workers,
         )
 
     def _predict_dataloader(self) -> DataLoader:
@@ -375,6 +381,7 @@ class DataModule(pl.LightningDataModule):
 
         collate_fn = self._resolve_collate_fn(predict_ds, RunningStage.PREDICTING)
         pin_memory = True
+        persistent_workers = False
 
         if isinstance(getattr(self, "trainer", None), pl.Trainer):
             return self.trainer.lightning_module.process_predict_dataset(
@@ -383,10 +390,15 @@ class DataModule(pl.LightningDataModule):
                 num_workers=self.num_workers,
                 pin_memory=pin_memory,
                 collate_fn=collate_fn,
+                persistent_workers=persistent_workers,
             )
 
         return DataLoader(
-            predict_ds, batch_size=batch_size, num_workers=self.num_workers, pin_memory=True, collate_fn=collate_fn
+            predict_ds, batch_size=batch_size, 
+            num_workers=self.num_workers, 
+            pin_memory=True, 
+            collate_fn=collate_fn,
+            persistent_workers=persistent_workers,
         )
 
     @property

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -288,7 +288,7 @@ class DataModule(pl.LightningDataModule):
         else:
             drop_last = len(train_ds) > self.batch_size
         pin_memory = True
-        persistent_workers = True
+        persistent_workers = self.num_workers > 0
 
         if self.sampler is None:
             sampler = None
@@ -324,7 +324,7 @@ class DataModule(pl.LightningDataModule):
         val_ds: Dataset = self._val_ds() if isinstance(self._val_ds, Callable) else self._val_ds
         collate_fn = self._resolve_collate_fn(val_ds, RunningStage.VALIDATING)
         pin_memory = True
-        persistent_workers = True
+        persistent_workers = self.num_workers > 0
 
         if isinstance(getattr(self, "trainer", None), pl.Trainer):
             return self.trainer.lightning_module.process_val_dataset(

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -394,9 +394,10 @@ class DataModule(pl.LightningDataModule):
             )
 
         return DataLoader(
-            predict_ds, batch_size=batch_size, 
-            num_workers=self.num_workers, 
-            pin_memory=True, 
+            predict_ds,
+            batch_size=batch_size,
+            num_workers=self.num_workers,
+            pin_memory=True,
             collate_fn=collate_fn,
             persistent_workers=persistent_workers,
         )

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -359,7 +359,6 @@ class DataModule(pl.LightningDataModule):
                 num_workers=self.num_workers,
                 pin_memory=pin_memory,
                 collate_fn=collate_fn,
-                persistent_workers=persistent_workers,
             )
 
         return DataLoader(
@@ -390,7 +389,6 @@ class DataModule(pl.LightningDataModule):
                 num_workers=self.num_workers,
                 pin_memory=pin_memory,
                 collate_fn=collate_fn,
-                persistent_workers=persistent_workers,
             )
 
         return DataLoader(

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -318,6 +318,7 @@ class DataModule(pl.LightningDataModule):
             pin_memory=pin_memory,
             drop_last=drop_last,
             collate_fn=collate_fn,
+            persistent_workers=persistent_workers,
         )
 
     def _val_dataloader(self) -> DataLoader:


### PR DESCRIPTION
## What does this PR do?

Enables `persistent_workers=True` on data loaders created via. a data module when a dataset (or set of datasets) is passed into the constructor.

Implements #811

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
