### PR TITLE
[Refactor] Improve preprocess / data_source relation

### DIFF
--- a/flash/core/data/data_pipeline.py
+++ b/flash/core/data/data_pipeline.py
@@ -26,7 +26,7 @@ from torch.utils.data import DataLoader, IterableDataset
 
 from flash.core.data.auto_dataset import IterableAutoDataset
 from flash.core.data.batch import _DeserializeProcessor, _Postprocessor, _Preprocessor, _Sequential, _SerializeProcessor
-from flash.core.data.data_source import DataSource
+from flash.core.data.data_source import DataSource, DataSourceCollection
 from flash.core.data.process import DefaultPreprocess, Deserializer, Postprocess, Preprocess, Serializer
 from flash.core.data.properties import ProcessState
 from flash.core.data.utils import _POSTPROCESS_FUNCS, _PREPROCESS_FUNCS, _STAGES_PREFIX
@@ -94,13 +94,15 @@ class DataPipeline:
     def __init__(
         self,
         data_source: Optional[DataSource] = None,
+        data_source_collection: Optional[DataSourceCollection] = None,
         preprocess: Optional[Preprocess] = None,
         postprocess: Optional[Postprocess] = None,
         deserializer: Optional[Deserializer] = None,
         serializer: Optional[Serializer] = None,
     ) -> None:
-        self.data_source = data_source
 
+        self._data_source = data_source
+        self._data_source_collection = data_source_collection
         self._preprocess_pipeline = preprocess or DefaultPreprocess()
         self._postprocess_pipeline = postprocess or Postprocess()
         self._serializer = serializer or Serializer()
@@ -113,8 +115,8 @@ class DataPipeline:
         give a warning."""
         data_pipeline_state = data_pipeline_state or DataPipelineState()
         data_pipeline_state._initialized = False
-        if self.data_source is not None:
-            self.data_source.attach_data_pipeline_state(data_pipeline_state)
+        if self._data_source is not None:
+            self._data_source.attach_data_pipeline_state(data_pipeline_state)
         self._preprocess_pipeline.attach_data_pipeline_state(data_pipeline_state)
         self._postprocess_pipeline.attach_data_pipeline_state(data_pipeline_state)
         self._serializer.attach_data_pipeline_state(data_pipeline_state)
@@ -559,7 +561,7 @@ class DataPipeline:
             model.predict_step = model.predict_step._original
 
     def __str__(self) -> str:
-        data_source: DataSource = self.data_source
+        data_source: DataSource = self._data_source
         preprocess: Preprocess = self._preprocess_pipeline
         postprocess: Postprocess = self._postprocess_pipeline
         serializer: Serializer = self._serializer

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -356,46 +356,50 @@ class DataSourceCollection(dict):
     def __init__(self, data_sources: Dict[str, DataSource], default_data_source: str):
         super().__init__(**data_sources)
         self.default_data_source = default_data_source
+        self[None] = self[default_data_source]
+        self["default"] = self[default_data_source]
 
-        for key, data_source in self.items():
-            func_name = f"from_{key.name.lower()}"
-            setattr(self, func_name, getattr(data_source, func_name, None))
+    def _execute(self, data_source_enum: DefaultDataSources, *args, **kwargs):
+        if data_source_enum in self:
+            func_name = f"from_{data_source_enum.name.lower()}"
+            return getattr(self[data_source_enum], func_name)(*args, **kwargs)
+        raise NotImplementedError
 
     def from_folders(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.FOLDERS, *args, **kwargs)
 
     def from_files(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.FILES, *args, **kwargs)
 
     def from_numpy(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.NUMPY, *args, **kwargs)
 
     def from_tensors(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.TENSORS, *args, **kwargs)
 
     def from_csv(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.CSV, *args, **kwargs)
 
     def from_json(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.JSON, *args, **kwargs)
 
     def from_datasets(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.DATASETS, *args, **kwargs)
 
     def from_fiftyone(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.FIFTYONE, *args, **kwargs)
 
     def from_dataframe(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.DATAFRAME, *args, **kwargs)
 
     def from_lists(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.LISTS, *args, **kwargs)
 
     def from_sentences(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.SENTENCES, *args, **kwargs)
 
     def from_labelstudio(self, *args, **kwargs):
-        raise NotImplementedError
+        return self._execute(DefaultDataSources.LABELSTUDIO, *args, **kwargs)
 
 
 SEQUENCE_DATA_TYPE = TypeVar("SEQUENCE_DATA_TYPE")

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -160,7 +160,7 @@ class DefaultDataSources(LightningEnum):
     JSON = "json"
     DATASETS = "datasets"
     FIFTYONE = "fiftyone"
-    DATAFRAME = "data_frame"
+    DATAFRAME = "dataframe"
     LISTS = "lists"
     SENTENCES = "sentences"
     LABELSTUDIO = "labelstudio"
@@ -350,6 +350,52 @@ class DataSource(Generic[DATA_TYPE], Properties, Module):
                 dataset = IterableAutoDataset(data, self, running_stage)
             dataset.__dict__.update(mock_dataset.metadata)
             return dataset
+
+
+class DataSourceCollection(dict):
+    def __init__(self, data_sources: Dict[str, DataSource], default_data_source: str):
+        super().__init__(**data_sources)
+        self.default_data_source = default_data_source
+
+        for key, data_source in self.items():
+            func_name = f"from_{key.name.lower()}"
+            setattr(self, func_name, getattr(data_source, func_name, None))
+
+    def from_folders(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_files(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_numpy(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_tensors(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_csv(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_json(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_datasets(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_fiftyone(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_dataframe(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_lists(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_sentences(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def from_labelstudio(self, *args, **kwargs):
+        raise NotImplementedError
 
 
 SEQUENCE_DATA_TYPE = TypeVar("SEQUENCE_DATA_TYPE")

--- a/flash/image/classification/adapters.py
+++ b/flash/image/classification/adapters.py
@@ -141,7 +141,7 @@ class Learn2LearnAdapter(Adapter):
 
         super().__init__()
 
-        self._task = NoModule(task)
+        self.__dict__["_task"] = task
         self.backbone = backbone
         self.head = head
         self.algorithm_cls = algorithm_cls
@@ -327,7 +327,7 @@ class Learn2LearnAdapter(Adapter):
             warning_cache.warn(
                 "When using a meta-learning training_strategy, the batch_size should be set to 1. "
                 "HINT: You can modify the `meta_batch_size` to 100 for example by doing "
-                f"{type(self._task.task)}" + "(training_strategies_kwargs={'meta_batch_size': 100})"
+                "(training_strategies_kwargs={'meta_batch_size': 100})"
             )
         return 1
 
@@ -479,7 +479,7 @@ class DefaultAdapter(Adapter):
     def __init__(self, task: AdapterTask, backbone: torch.nn.Module, head: torch.nn.Module):
         super().__init__()
 
-        self._task = NoModule(task)
+        self.__dict__["_task"] = task
         self.backbone = backbone
         self.head = head
 
@@ -497,19 +497,19 @@ class DefaultAdapter(Adapter):
 
     def training_step(self, batch: Any, batch_idx: int) -> Any:
         batch = (batch[DefaultDataKeys.INPUT], batch[DefaultDataKeys.TARGET])
-        return Task.training_step(self._task.task, batch, batch_idx)
+        return Task.training_step(self.__dict__["_task"], batch, batch_idx)
 
     def validation_step(self, batch: Any, batch_idx: int) -> Any:
         batch = (batch[DefaultDataKeys.INPUT], batch[DefaultDataKeys.TARGET])
-        return Task.validation_step(self._task.task, batch, batch_idx)
+        return Task.validation_step(self.__dict__["_task"], batch, batch_idx)
 
     def test_step(self, batch: Any, batch_idx: int) -> Any:
         batch = (batch[DefaultDataKeys.INPUT], batch[DefaultDataKeys.TARGET])
-        return Task.test_step(self._task.task, batch, batch_idx)
+        return Task.test_step(self.__dict__["_task"], batch, batch_idx)
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> Any:
         batch[DefaultDataKeys.PREDS] = Task.predict_step(
-            self._task.task, (batch[DefaultDataKeys.INPUT]), batch_idx, dataloader_idx=dataloader_idx
+            self.__dict__["_task"], (batch[DefaultDataKeys.INPUT]), batch_idx, dataloader_idx=dataloader_idx
         )
         return batch
 

--- a/flash/image/classification/data.py
+++ b/flash/image/classification/data.py
@@ -22,7 +22,12 @@ from torch.utils.data.sampler import Sampler
 from flash.core.data.base_viz import BaseVisualization  # for viz
 from flash.core.data.callback import BaseDataFetcher
 from flash.core.data.data_module import DataModule
-from flash.core.data.data_source import DefaultDataKeys, DefaultDataSources, LoaderDataFrameDataSource
+from flash.core.data.data_source import (
+    DataSourceCollection,
+    DefaultDataKeys,
+    DefaultDataSources,
+    LoaderDataFrameDataSource,
+)
 from flash.core.data.process import Deserializer, Preprocess
 from flash.core.integrations.labelstudio.data_source import LabelStudioImageClassificationDataSource
 from flash.core.utilities.imports import _MATPLOTLIB_AVAILABLE, Image, requires
@@ -52,6 +57,65 @@ class ImageClassificationDataFrameDataSource(LoaderDataFrameDataSource):
         w, h = sample[DefaultDataKeys.INPUT].size  # WxH
         sample[DefaultDataKeys.METADATA]["size"] = (h, w)
         return sample
+
+    @classmethod
+    def from_csv(
+        cls,
+        input_field: str,
+        target_fields: Optional[Union[str, Sequence[str]]] = None,
+        train_file: Optional[str] = None,
+        train_images_root: Optional[str] = None,
+        train_resolver: Optional[Callable[[str, str], str]] = None,
+        val_file: Optional[str] = None,
+        val_images_root: Optional[str] = None,
+        val_resolver: Optional[Callable[[str, str], str]] = None,
+        test_file: Optional[str] = None,
+        test_images_root: Optional[str] = None,
+        test_resolver: Optional[Callable[[str, str], str]] = None,
+        predict_file: Optional[str] = None,
+        predict_images_root: Optional[str] = None,
+        predict_resolver: Optional[Callable[[str, str], str]] = None,
+        **data_source_kwargs: Any,
+    ) -> Any:
+        """Creates a :class:`~flash.image.classification.data.ImageClassificationData` object from the given CSV
+        files using the :class:`~flash.core.data.data_source.DataSource` of name
+        :attr:`~flash.core.data.data_source.DefaultDataSources.CSV` from the passed or constructed
+        :class:`~flash.core.data.process.Preprocess`.
+
+        Args:
+            input_field: The field (column) in the CSV file to use for the input.
+            target_fields: The field or fields (columns) in the CSV file to use for the target.
+            train_file: The CSV file containing the training data.
+            train_images_root: The directory containing the train images. If ``None``, the directory containing the
+                ``train_file`` will be used.
+            train_resolver: The function to use to resolve filenames given the ``train_images_root`` and IDs from the
+                ``input_field`` column.
+            val_file: The CSV file containing the validation data.
+            val_images_root: The directory containing the validation images. If ``None``, the directory containing the
+                ``val_file`` will be used.
+            val_resolver: The function to use to resolve filenames given the ``val_images_root`` and IDs from the
+                ``input_field`` column.
+            test_file: The CSV file containing the testing data.
+            test_images_root: The directory containing the test images. If ``None``, the directory containing the
+                ``test_file`` will be used.
+            test_resolver: The function to use to resolve filenames given the ``test_images_root`` and IDs from the
+                ``input_field`` column.
+            predict_file: The CSV file containing the data to use when predicting.
+            predict_images_root: The directory containing the predict images. If ``None``, the directory containing the
+                ``predict_file`` will be used.
+            predict_resolver: The function to use to resolve filenames given the ``predict_images_root`` and IDs from
+                the ``input_field`` column.
+            data_source_kwargs: Additional keyword arguments to use when constructing the data source.
+
+        Returns:
+            The constructed data module.
+        """
+        return cls(**data_source_kwargs).to_datasets(
+            (train_file, input_field, target_fields, train_images_root, train_resolver),
+            (val_file, input_field, target_fields, val_images_root, val_resolver),
+            (test_file, input_field, target_fields, test_images_root, test_resolver),
+            (predict_file, input_field, target_fields, predict_images_root, predict_resolver),
+        )
 
 
 class ImageClassificationPreprocess(Preprocess):
@@ -380,3 +444,236 @@ class MatplotlibVisualization(BaseVisualization):
     def show_per_batch_transform(self, batch: List[Any], running_stage):
         win_title: str = f"{running_stage} - show_per_batch_transform"
         self._show_images_and_labels(batch[0], batch[0][DefaultDataKeys.INPUT].shape[0], win_title)
+
+
+class ImageClassificationDataSourceCollection(DataSourceCollection):
+    def __init__(self, **data_source_kwargs):
+        super().__init__(
+            data_sources={
+                DefaultDataSources.FIFTYONE: ImageFiftyOneDataSource(**data_source_kwargs),
+                DefaultDataSources.FILES: ImagePathsDataSource(),
+                DefaultDataSources.FOLDERS: ImagePathsDataSource(),
+                DefaultDataSources.NUMPY: ImageNumpyDataSource(),
+                DefaultDataSources.TENSORS: ImageTensorDataSource(),
+                DefaultDataSources.DATAFRAME: ImageClassificationDataFrameDataSource(),
+                DefaultDataSources.CSV: ImageClassificationDataFrameDataSource(),
+                DefaultDataSources.LABELSTUDIO: LabelStudioImageClassificationDataSource(),
+            },
+            default_data_source=DefaultDataSources.FILES,
+        )
+
+
+class ImageClassificationDataV2(DataModule):
+
+    preprocess_cls = ImageClassificationPreprocess
+    data_source_collection_cls = ImageClassificationDataSourceCollection
+
+    @classmethod
+    def from_data_source(
+        cls,
+        data_source,
+        train_dataset: Any = None,
+        val_dataset: Any = None,
+        test_dataset: Any = None,
+        predict_dataset: Any = None,
+        train_transform: Optional[Union[Callable, List, Dict[str, Callable]]] = None,
+        val_transform: Optional[Union[Callable, List, Dict[str, Callable]]] = None,
+        test_transform: Optional[Union[Callable, List, Dict[str, Callable]]] = None,
+        predict_transform: Optional[Dict[str, Callable]] = None,
+        data_fetcher: Optional[BaseDataFetcher] = None,
+        preprocess: Optional[Preprocess] = None,
+        val_split: Optional[float] = None,
+        batch_size: int = 4,
+        num_workers: int = 0,
+        sampler: Optional[Type[Sampler]] = None,
+        **preprocess_kwargs: Any,
+    ) -> "DataModule":
+        """Creates a :class:`~flash.core.data.data_module.DataModule` object from the given inputs to
+        :meth:`~flash.core.data.data_source.DataSource.load_data` (``train_data``, ``val_data``, ``test_data``,
+        ``predict_data``). The data source will be resolved from the instantiated
+        :class:`~flash.core.data.process.Preprocess`
+        using :meth:`~flash.core.data.process.Preprocess.data_source_of_name`.
+
+        Args:
+            data_source: The name of the data source to use for the
+                :meth:`~flash.core.data.data_source.DataSource.load_data`.
+            train_data: The input to :meth:`~flash.core.data.data_source.DataSource.load_data` to use when creating
+                the train dataset.
+            val_data: The input to :meth:`~flash.core.data.data_source.DataSource.load_data` to use when creating
+                the validation dataset.
+            test_data: The input to :meth:`~flash.core.data.data_source.DataSource.load_data` to use when creating
+                the test dataset.
+            predict_data: The input to :meth:`~flash.core.data.data_source.DataSource.load_data` to use when creating
+                the predict dataset.
+            train_transform: The dictionary of transforms to use during training which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            val_transform: The dictionary of transforms to use during validation which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            test_transform: The dictionary of transforms to use during testing which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            predict_transform: The dictionary of transforms to use during predicting which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            data_fetcher: The :class:`~flash.core.data.callback.BaseDataFetcher` to pass to the
+                :class:`~flash.core.data.data_module.DataModule`.
+            preprocess: The :class:`~flash.core.data.data.Preprocess` to pass to the
+                :class:`~flash.core.data.data_module.DataModule`. If ``None``, ``cls.preprocess_cls`` will be
+                constructed and used.
+            val_split: The ``val_split`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            batch_size: The ``batch_size`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            num_workers: The ``num_workers`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            sampler: The ``sampler`` to use for the ``train_dataloader``.
+            preprocess_kwargs: Additional keyword arguments to use when constructing the preprocess. Will only be used
+                if ``preprocess = None``.
+
+        Returns:
+            The constructed data module.
+
+        Examples::
+
+            data_module = DataModule.from_data_source(
+                DefaultDataSources.FOLDERS,
+                train_data="train_folder",
+                train_transform={
+                    "to_tensor_transform": torch.as_tensor,
+                },
+            )
+        """
+
+        preprocess = preprocess or cls.preprocess_cls(
+            train_transform,
+            val_transform,
+            test_transform,
+            predict_transform,
+            **preprocess_kwargs,
+        )
+
+        return cls(
+            train_dataset,
+            val_dataset,
+            test_dataset,
+            predict_dataset,
+            data_source=data_source,
+            preprocess=preprocess,
+            data_fetcher=data_fetcher,
+            val_split=val_split,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            sampler=sampler,
+        )
+
+    @classmethod
+    def from_csv(
+        cls,
+        input_field: str,
+        target_fields: Optional[Union[str, Sequence[str]]] = None,
+        train_file: Optional[str] = None,
+        train_images_root: Optional[str] = None,
+        train_resolver: Optional[Callable[[str, str], str]] = None,
+        val_file: Optional[str] = None,
+        val_images_root: Optional[str] = None,
+        val_resolver: Optional[Callable[[str, str], str]] = None,
+        test_file: Optional[str] = None,
+        test_images_root: Optional[str] = None,
+        test_resolver: Optional[Callable[[str, str], str]] = None,
+        predict_file: Optional[str] = None,
+        predict_images_root: Optional[str] = None,
+        predict_resolver: Optional[Callable[[str, str], str]] = None,
+        train_transform: Optional[Union[Callable, List, Dict[str, Callable]]] = None,
+        val_transform: Optional[Union[Callable, List, Dict[str, Callable]]] = None,
+        test_transform: Optional[Union[Callable, List, Dict[str, Callable]]] = None,
+        predict_transform: Optional[Dict[str, Callable]] = None,
+        data_fetcher: Optional[BaseDataFetcher] = None,
+        preprocess: Optional[Preprocess] = None,
+        val_split: Optional[float] = None,
+        batch_size: int = 4,
+        num_workers: int = 0,
+        sampler: Optional[Type[Sampler]] = None,
+        **preprocess_kwargs: Any,
+    ) -> "DataModule":
+        """Creates a :class:`~flash.image.classification.data.ImageClassificationData` object from the given CSV
+        files using the :class:`~flash.core.data.data_source.DataSource` of name
+        :attr:`~flash.core.data.data_source.DefaultDataSources.CSV` from the passed or constructed
+        :class:`~flash.core.data.process.Preprocess`.
+
+        Args:
+            input_field: The field (column) in the CSV file to use for the input.
+            target_fields: The field or fields (columns) in the CSV file to use for the target.
+            train_file: The CSV file containing the training data.
+            train_images_root: The directory containing the train images. If ``None``, the directory containing the
+                ``train_file`` will be used.
+            train_resolver: The function to use to resolve filenames given the ``train_images_root`` and IDs from the
+                ``input_field`` column.
+            val_file: The CSV file containing the validation data.
+            val_images_root: The directory containing the validation images. If ``None``, the directory containing the
+                ``val_file`` will be used.
+            val_resolver: The function to use to resolve filenames given the ``val_images_root`` and IDs from the
+                ``input_field`` column.
+            test_file: The CSV file containing the testing data.
+            test_images_root: The directory containing the test images. If ``None``, the directory containing the
+                ``test_file`` will be used.
+            test_resolver: The function to use to resolve filenames given the ``test_images_root`` and IDs from the
+                ``input_field`` column.
+            predict_file: The CSV file containing the data to use when predicting.
+            predict_images_root: The directory containing the predict images. If ``None``, the directory containing the
+                ``predict_file`` will be used.
+            predict_resolver: The function to use to resolve filenames given the ``predict_images_root`` and IDs from
+                the ``input_field`` column.
+            train_transform: The dictionary of transforms to use during training which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            val_transform: The dictionary of transforms to use during validation which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            test_transform: The dictionary of transforms to use during testing which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            predict_transform: The dictionary of transforms to use during predicting which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            data_fetcher: The :class:`~flash.core.data.callback.BaseDataFetcher` to pass to the
+                :class:`~flash.core.data.data_module.DataModule`.
+            preprocess: The :class:`~flash.core.data.data.Preprocess` to pass to the
+                :class:`~flash.core.data.data_module.DataModule`. If ``None``, ``cls.preprocess_cls``
+                will be constructed and used.
+            val_split: The ``val_split`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            batch_size: The ``batch_size`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            num_workers: The ``num_workers`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            sampler: The ``sampler`` to use for the ``train_dataloader``.
+            preprocess_kwargs: Additional keyword arguments to use when constructing the preprocess. Will only be used
+                if ``preprocess = None``.
+
+        Returns:
+            The constructed data module.
+        """
+        data_source_collection = cls.data_source_collection_cls(**preprocess_kwargs)
+        train_ds, val_test, test_ds, predict_ds = data_source_collection.from_csv(
+            input_field=input_field,
+            target_fields=target_fields,
+            train_file=train_file,
+            train_images_root=train_images_root,
+            train_resolver=train_resolver,
+            val_file=val_file,
+            val_images_root=val_images_root,
+            val_resolver=val_resolver,
+            test_file=test_file,
+            test_images_root=test_images_root,
+            test_resolver=test_resolver,
+            predict_file=predict_file,
+            predict_images_root=predict_images_root,
+            predict_resolver=predict_resolver,
+        )
+
+        return cls.from_data_source(
+            data_source_collection[DefaultDataSources.CSV],
+            train_ds,
+            val_test,
+            test_ds,
+            predict_ds,
+            train_transform=train_transform,
+            val_transform=val_transform,
+            test_transform=test_transform,
+            predict_transform=predict_transform,
+            data_fetcher=data_fetcher,
+            preprocess=preprocess,
+            val_split=val_split,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            sampler=sampler,
+            **preprocess_kwargs,
+        )

--- a/tests/image/classification/test_data.py
+++ b/tests/image/classification/test_data.py
@@ -618,9 +618,9 @@ def test_albumentations_mixup(single_target_csv):
 
 def test_data_source_collection(single_target_csv, tmpdir):
 
-    data_source = ImageClassificationDataSourceCollection()
+    loader = ImageClassificationDataSourceCollection()
 
-    train_ds, val_ds, test_ds, predict_ds = data_source.from_csv(
+    train_ds, val_ds, test_ds, predict_ds = loader.from_csv(
         "image",
         "target",
         train_file=single_target_csv,

--- a/tests/image/classification/test_data.py
+++ b/tests/image/classification/test_data.py
@@ -650,6 +650,10 @@ def test_data_source_collection(single_target_csv, tmpdir):
     trainer = flash.Trainer(default_root_dir=tmpdir, fast_dev_run=True)
     trainer.finetune(model, dm, strategy="freeze_unfreeze")
 
+    checkpoint_path = str(tmpdir / "model.pt")
+    trainer.save_checkpoint(checkpoint_path)
+    model = ImageClassifier.load_from_checkpoint(checkpoint_path)
+
     path = os.path.join(os.path.dirname(single_target_csv), "image_1.png")
     assert model.predict([path])
     assert trainer.predict(model, dm)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Currently, the Processing part of Flash is quite confusing.
This is due the preprocess owning the data sources and de-serializer.

This PR introduces a DataSourceCollection which would be its own object and be used to create dataset for the users who might want to opt-out of Flash.

But this also makes DataModule code more readable as more sequential.

API

```py
    loader = ImageClassificationDataSourceCollection()

    train_ds, val_ds, test_ds, predict_ds = loader.from_csv(
        "image",
        "target",
        train_file=single_target_csv,
    )

    assert train_ds
    assert not val_ds
    assert not test_ds
    assert not predict_ds

    dm = ImageClassificationDataV2.from_csv(
        "image",
        "target",
        train_file=single_target_csv,
        predict_file=single_target_csv,
        batch_size=2,
        num_workers=0,
        train_transform=default_transforms((256, 256)),
        predict_transform=default_transforms((256, 256)),
    )

    batch = next(iter(dm.train_dataloader()))
    assert batch
```

Example for the ImageClassificationDataSourceCollection

```py
class ImageClassificationDataSourceCollection(DataSourceCollection):
    def __init__(self, **data_source_kwargs):
        super().__init__(
            data_sources={
                DefaultDataSources.FIFTYONE: ImageFiftyOneDataSource(**data_source_kwargs),
                DefaultDataSources.FILES: ImagePathsDataSource(),
                DefaultDataSources.FOLDERS: ImagePathsDataSource(),
                DefaultDataSources.NUMPY: ImageNumpyDataSource(),
                DefaultDataSources.TENSORS: ImageTensorDataSource(),
                DefaultDataSources.DATAFRAME: ImageClassificationDataFrameDataSource(),
                DefaultDataSources.CSV: ImageClassificationDataFrameDataSource(),
                DefaultDataSources.LABELSTUDIO: LabelStudioImageClassificationDataSource(),
            },
            default_data_source=DefaultDataSources.FILES,
        )


class ImageClassificationDataV2(DataModule):

    preprocess_cls = ImageClassificationPreprocessV2
    data_source_collection_cls = ImageClassificationDataSourceCollection
    deserializer_cls = ImageDeserializer
```

Here is the class_method from the DataModule. As one can see, the data_source_collection is used to extract the associated data_soruce and create his datasets.

```py
        data_source_collection = cls.data_source_collection_cls(**preprocess_kwargs)
        data_source: ImageClassificationDataFrameDataSource = data_source_collection[DefaultDataSources.CSV]
        train_ds, val_test, test_ds, predict_ds = data_source.from_csv(
            input_field=input_field,
            target_fields=target_fields,
            train_file=train_file,
            train_images_root=train_images_root,
            train_resolver=train_resolver,
            val_file=val_file,
            val_images_root=val_images_root,
            val_resolver=val_resolver,
            test_file=test_file,
            test_images_root=test_images_root,
            test_resolver=test_resolver,
            predict_file=predict_file,
            predict_images_root=predict_images_root,
            predict_resolver=predict_resolver,
        )

        return cls.from_data_source(
            data_source,
            data_source_collection,
            train_ds,
            val_test,
            test_ds,
            predict_ds,
            train_transform=train_transform,
            val_transform=val_transform,
            test_transform=test_transform,
            predict_transform=predict_transform,
            data_fetcher=data_fetcher,
            preprocess=preprocess,
            val_split=val_split,
            batch_size=batch_size,
            num_workers=num_workers,
            sampler=sampler,
            **preprocess_kwargs,
        )
```

Fixes #778

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
