### PR TITLE
Add val_loss and test_loss calculation and logging for QnA task

### DIFF
--- a/flash/text/question_answering/model.py
+++ b/flash/text/question_answering/model.py
@@ -251,12 +251,13 @@ class QuestionAnsweringTask(Task):
     def forward(self, batch: Any) -> Any:
         metadata = batch.pop(DefaultDataKeys.METADATA)
         outputs = self.model(**batch)
+        loss = outputs.loss
         start_logits = outputs.start_logits
         end_logits = outputs.end_logits
 
         generated_answers = self._generate_answers(start_logits, end_logits, metadata)
         batch[DefaultDataKeys.METADATA] = metadata
-        return generated_answers
+        return loss, generated_answers
 
     def training_step(self, batch: Any, batch_idx: int) -> Tensor:
         outputs = self.model(**batch)
@@ -265,9 +266,10 @@ class QuestionAnsweringTask(Task):
         return loss
 
     def common_step(self, prefix: str, batch: Any) -> torch.Tensor:
-        generated_answers = self(batch)
+        loss, generated_answers = self(batch)
         result = self.compute_metrics(generated_answers, batch[DefaultDataKeys.METADATA])
-        self.log_dict(result, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(f"{prefix}_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log_dict(result, on_step=False, on_epoch=True, prog_bar=False)
 
     def compute_metrics(self, generated_tokens, batch):
         for example in batch:
@@ -285,7 +287,7 @@ class QuestionAnsweringTask(Task):
         self.common_step("test", batch)
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> Any:
-        generated_answers = self(batch)
+        _, generated_answers = self(batch)
         return generated_answers
 
     @property

--- a/tests/text/question_answering/test_data.py
+++ b/tests/text/question_answering/test_data.py
@@ -136,6 +136,8 @@ def test_from_files(tmpdir):
     batch = next(iter(dm.val_dataloader()))
     assert "input_ids" in batch
     assert "attention_mask" in batch
+    assert "start_positions" in batch
+    assert "end_positions" in batch
     assert DefaultDataKeys.METADATA in batch
     assert "context" in batch[DefaultDataKeys.METADATA][0]
     assert "answer" in batch[DefaultDataKeys.METADATA][0]
@@ -145,6 +147,8 @@ def test_from_files(tmpdir):
     batch = next(iter(dm.test_dataloader()))
     assert "input_ids" in batch
     assert "attention_mask" in batch
+    assert "start_positions" in batch
+    assert "end_positions" in batch
     assert DefaultDataKeys.METADATA in batch
     assert "context" in batch[DefaultDataKeys.METADATA][0]
     assert "answer" in batch[DefaultDataKeys.METADATA][0]


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
Fixes # (issue)
-->

Currently the QnA Task doesn't log `val_loss` and `test_loss` by which some users maybe facing difficulty to take decisions on training.

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
