### PR TITLE
HotFix for doc build on master

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,7 @@ try:
 except ModuleNotFoundError:
 
     about = _load_py_module("__about__.py")
-    providers = _load_py_module("flash/core/utilities/providers.py")
+    providers = _load_py_module("core/utilities/providers.py")
 
 SPHINX_MOCK_REQUIREMENTS = int(os.environ.get("SPHINX_MOCK_REQUIREMENTS", True))
 
@@ -210,7 +210,7 @@ PACKAGE_MAPPING = {
     "pytorch-tabnet": "pytorch_tabnet",
     "pyDeprecate": "deprecate",
 }
-MOCK_PACKAGES = ["numpy", "PyYAML", "tqdm"]
+MOCK_PACKAGES = ["PyYAML", "tqdm"]
 if SPHINX_MOCK_REQUIREMENTS:
     # mock also base packages when we are on RTD since we don't install them there
     MOCK_PACKAGES += _package_list_from_file(os.path.join(_PATH_ROOT, "requirements.txt"))

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -13,3 +13,4 @@ sphinx-paramlinks>=0.5.1
 sphinx-togglebutton>=0.2
 sphinx-copybutton>=0.3
 jinja2
+numpy>=1.21.2 # hotfix for docs, failing without numpy install


### PR DESCRIPTION
## What does this PR do?

Currently the docs are failing on master. This seems to be because of a numpy error. Mocking this seems to not work, thus for now installing the library within the docs may be a suitable hotfix.