### PR TITLE
drop params from hparams of Tab. forecasting

### DIFF
--- a/flash/tabular/forecasting/model.py
+++ b/flash/tabular/forecasting/model.py
@@ -37,8 +37,7 @@ class TabularForecaster(AdapterTask):
         metrics: Union[torchmetrics.Metric, List[torchmetrics.Metric]] = None,
         learning_rate: float = 4e-3,
     ):
-
-        self.save_hyperparameters()
+        self.save_hyperparameters(ignore="parameters")
 
         if backbone_kwargs is None:
             backbone_kwargs = {}


### PR DESCRIPTION
## What does this PR do?

Preventing hparams failed on:
```
/opt/conda/lib/python3.7/site-packages/pytorch_lightning/core/saving.py in save_hparams_to_yaml(config_yaml, hparams)
    403     for k, v in hparams.items():
    404         try:
--> 405             yaml.dump(v)
    406         except TypeError:
    407             warn(f"Skipping '{k}' parameter because it is not possible to safely dump to YAML.")

/opt/conda/lib/python3.7/site-packages/yaml/__init__.py in dump(data, stream, Dumper, **kwds)
    288     If stream is None, return the produced string instead.
    289     """
--> 290     return dump_all([data], stream, Dumper=Dumper, **kwds)
    291 
    292 def safe_dump_all(documents, stream=None, **kwds):

...

/opt/conda/lib/python3.7/site-packages/yaml/representer.py in represent_object(self, data)
    329         if dictitems is not None:
    330             dictitems = dict(dictitems)
--> 331         if function.__name__ == '__newobj__':
    332             function = args[0]
    333             args = args[1:]

AttributeError: 'functools.partial' object has no attribute '__name__'
```

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
