### PR TITLE
Fix RTD build

### DIFF
--- a/flash/core/data/io/input_base.py
+++ b/flash/core/data/io/input_base.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 import functools
 import sys
-from typing import Any, cast, Dict, Iterable, MutableMapping, Sequence, Tuple, Union
+from typing import Any, cast, Dict, Iterable, MutableMapping, Sequence, Tuple, TYPE_CHECKING, Union
 
-from torch.utils.data import Dataset, IterableDataset
+from torch.utils.data import Dataset
 
 from flash.core.data.properties import Properties
 from flash.core.utilities.stages import RunningStage
@@ -24,6 +24,12 @@ if sys.version_info < (3, 7):
     from typing import GenericMeta
 else:
     GenericMeta = type
+
+
+if not TYPE_CHECKING:
+    from torch.utils.data import IterableDataset
+else:
+    IterableDataset = object
 
 
 def _has_len(data: Union[Sequence, Iterable]) -> bool:

--- a/flash/core/data/io/input_base.py
+++ b/flash/core/data/io/input_base.py
@@ -30,6 +30,8 @@ else:
 if not os.environ.get("READTHEDOCS", False):
     from torch.utils.data import IterableDataset
 else:
+    # ReadTheDocs mocks the `IterableDataset` import so it's type cannot be used as a base for a metaclass, so we
+    # replace it here.
     IterableDataset = object
 
 

--- a/flash/core/data/io/input_base.py
+++ b/flash/core/data/io/input_base.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
+import os
 import sys
-from typing import Any, cast, Dict, Iterable, MutableMapping, Sequence, Tuple, TYPE_CHECKING, Union
+from typing import Any, cast, Dict, Iterable, MutableMapping, Sequence, Tuple, Union
 
 from torch.utils.data import Dataset
 
@@ -26,7 +27,7 @@ else:
     GenericMeta = type
 
 
-if not TYPE_CHECKING:
+if not os.environ.get("READTHEDOCS", False):
     from torch.utils.data import IterableDataset
 else:
     IterableDataset = object


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

The read the docs build environment (where the "READTHEDOCS" environment variable is set to True) doesn't include torch so it mocks the `IterableDataset` import. Whatever type that mock is doesn't then work as a base for a metaclass. So we instead replace the import with `object` since `type(object) = type` and `type` is the natural base for a Python metaclass.

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
