### PR TITLE
Fix checkpointing bug in tabular forecasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed a bug where translation metrics were not computed correctly ([#992](https://github.com/PyTorchLightning/lightning-flash/pull/992))
 
+- Fixed a bug where the TabularForecaster would not work with some versions of pandas ([#995](https://github.com/PyTorchLightning/lightning-flash/pull/995))
+
 ### Removed
 
 - Removed `OutputMapping` ([#939](https://github.com/PyTorchLightning/lightning-flash/pull/939))

--- a/flash/core/integrations/pytorch_forecasting/adapter.py
+++ b/flash/core/integrations/pytorch_forecasting/adapter.py
@@ -76,7 +76,7 @@ class PyTorchForecastingAdapter(Adapter):
     ) -> Adapter:
         parameters = copy(parameters)
         # Remove the single row of data from the parameters to reconstruct the `time_series_dataset`
-        data = parameters.pop("data_sample")
+        data = DataFrame.from_dict(parameters.pop("data_sample"))
         time_series_dataset = PatchTimeSeriesDataSet.from_parameters(parameters, data)
 
         backbone_kwargs["loss"] = loss_fn

--- a/flash/tabular/forecasting/data.py
+++ b/flash/tabular/forecasting/data.py
@@ -62,7 +62,7 @@ class TabularForecastingDataFrameInput(Input):
             parameters = time_series_dataset.get_parameters()
 
             # Add some sample data so that we can recreate the `TimeSeriesDataSet` later on
-            parameters["data_sample"] = data.iloc[[0]]
+            parameters["data_sample"] = data.iloc[[0]].to_dict()
 
             self.set_state(TimeSeriesDataSetParametersState(parameters))
             self.parameters = parameters

--- a/flash/tabular/forecasting/model.py
+++ b/flash/tabular/forecasting/model.py
@@ -37,7 +37,7 @@ class TabularForecaster(AdapterTask):
         metrics: Union[torchmetrics.Metric, List[torchmetrics.Metric]] = None,
         learning_rate: float = 4e-3,
     ):
-        self.save_hyperparameters(ignore="parameters")
+        self.save_hyperparameters()
 
         if backbone_kwargs is None:
             backbone_kwargs = {}


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

The parameters are needed to restore the checkpoint, but pandas data frames can't be pickled in some versions of pandas. This PR changes it to store the first row of data as a dict (inherently serializable) rather than a dataframe.

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
