### PR TITLE
Added references to object detection formats

### DIFF
--- a/flash/image/detection/data.py
+++ b/flash/image/detection/data.py
@@ -93,7 +93,7 @@ class ObjectDetectionData(DataModule):
         **data_module_kwargs: Any,
     ) -> "ObjectDetectionData":
         """Creates a :class:`~flash.image.detection.data.ObjectDetectionData` object from the given data folders
-        and annotation files in the COCO format.
+        and annotation files in the `COCO JSON format <https://cocodataset.org/#format-data>`_.
 
         Args:
             train_folder: The folder containing the train data.
@@ -152,15 +152,16 @@ class ObjectDetectionData(DataModule):
         **data_module_kwargs: Any,
     ) -> "ObjectDetectionData":
         """Creates a :class:`~flash.image.detection.data.ObjectDetectionData` object from the given data folders
-        and annotation files in the VOC format.
+        and annotation files in the `PASCAL VOC (Visual Obect Challenge) <http://host.robots.ox.ac.uk/pascal/VOC/>`_
+        XML format.
 
         Args:
             train_folder: The folder containing the train data.
-            train_ann_file: The COCO format annotation file.
+            train_ann_file: The VOC format annotation file.
             val_folder: The folder containing the validation data.
-            val_ann_file: The COCO format annotation file.
+            val_ann_file: The VOC format annotation file.
             test_folder: The folder containing the test data.
-            test_ann_file: The COCO format annotation file.
+            test_ann_file: The VOC format annotation file.
             predict_folder: The folder containing the predict data.
             train_transform: The dictionary of transforms to use during training which maps
                 :class:`~flash.core.data.io.input_transform.InputTransform` hook names to callable transforms.
@@ -211,15 +212,16 @@ class ObjectDetectionData(DataModule):
         **data_module_kwargs: Any,
     ) -> "ObjectDetectionData":
         """Creates a :class:`~flash.image.detection.data.ObjectDetectionData` object from the given data folders
-        and annotation files in the VIA format.
+        and annotation files in the VIA (`VGG Image Annotator <https://www.robots.ox.ac.uk/~vgg/software/via/>`_) 
+        `JSON format <https://gitlab.com/vgg/via/-/blob/via-3.x.y/via-3.x.y/CodeDoc.md#structure-of-via-project-json-file>`_.
 
         Args:
             train_folder: The folder containing the train data.
-            train_ann_file: The COCO format annotation file.
+            train_ann_file: The VIA format annotation file.
             val_folder: The folder containing the validation data.
-            val_ann_file: The COCO format annotation file.
+            val_ann_file: The VIA format annotation file.
             test_folder: The folder containing the test data.
-            test_ann_file: The COCO format annotation file.
+            test_ann_file: The VIA format annotation file.
             predict_folder: The folder containing the predict data.
             train_transform: The dictionary of transforms to use during training which maps
                 :class:`~flash.core.data.io.input_transform.InputTransform` hook names to callable transforms.

--- a/flash/image/detection/data.py
+++ b/flash/image/detection/data.py
@@ -152,8 +152,8 @@ class ObjectDetectionData(DataModule):
         **data_module_kwargs: Any,
     ) -> "ObjectDetectionData":
         """Creates a :class:`~flash.image.detection.data.ObjectDetectionData` object from the given data folders
-        and annotation files in the `PASCAL VOC (Visual Obect Challenge) <http://host.robots.ox.ac.uk/pascal/VOC/>`_
-        XML format.
+        and annotation files in the `PASCAL VOC (Visual Obect Challenge)
+        <http://host.robots.ox.ac.uk/pascal/VOC/>`_ XML format.
 
         Args:
             train_folder: The folder containing the train data.
@@ -212,8 +212,9 @@ class ObjectDetectionData(DataModule):
         **data_module_kwargs: Any,
     ) -> "ObjectDetectionData":
         """Creates a :class:`~flash.image.detection.data.ObjectDetectionData` object from the given data folders
-        and annotation files in the VIA (`VGG Image Annotator <https://www.robots.ox.ac.uk/~vgg/software/via/>`_) 
-        `JSON format <https://gitlab.com/vgg/via/-/blob/via-3.x.y/via-3.x.y/CodeDoc.md#structure-of-via-project-json-file>`_.
+        and annotation files in the VIA (`VGG Image Annotator <https://www.robots.ox.ac.uk/~vgg/software/via/>`_)
+        `JSON format <https://gitlab.com/vgg/via/-/blob/via-3.x.y/via-3.x.y/CodeDoc.md#structure-of-via-project-
+        json-file>`_.
 
         Args:
             train_folder: The folder containing the train data.


### PR DESCRIPTION
And also corrected erroneous mentions of COCO format in `from_voc` and `from_via` methods.

## What does this PR do?

This PR makes the [Object Detection API documentation](https://lightning-flash.readthedocs.io/en/latest/api/generated/flash.image.detection.data.ObjectDetectionData.html) clearer by providing references to the COCO, VIA, and VOC formats. I also corrected a few times where COCO format was mentioned.

Fixes #1070

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests? [not needed for typos/docs]
- [X] Did you verify new and existing tests pass locally with your changes?
- [X] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
