### PR TITLE
fix from_data_frame factory method with prediction df

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed a bug where passing the `val_split` to the `DataModule` would not have the desired effect ([#1079](https://github.com/PyTorchLightning/lightning-flash/pull/1079))
 
+- Fixed a bug where passing `predict_data_frame` to `ImageClassificationData.from_data_frame` raised an error ([#1088](https://github.com/PyTorchLightning/lightning-flash/pull/1088))
+
 ### Removed
 
 ## [0.6.0] - 2021-13-12

--- a/flash/image/classification/data.py
+++ b/flash/image/classification/data.py
@@ -217,7 +217,7 @@ class ImageClassificationData(DataModule):
         train_data = (train_data_frame, input_field, target_fields, train_images_root, train_resolver)
         val_data = (val_data_frame, input_field, target_fields, val_images_root, val_resolver)
         test_data = (test_data_frame, input_field, target_fields, test_images_root, test_resolver)
-        predict_data = (predict_data_frame, input_field, predict_images_root, predict_resolver)
+        predict_data = (predict_data_frame, input_field, None, predict_images_root, predict_resolver)
 
         return cls(
             input_cls(RunningStage.TRAINING, *train_data, transform=train_transform, **ds_kw),

--- a/tests/image/classification/test_data.py
+++ b/tests/image/classification/test_data.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, List, Tuple
 
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
@@ -82,6 +83,55 @@ def test_from_filepaths_smoke(tmpdir):
     assert imgs.shape == (2, 3, 196, 196)
     assert labels.shape == (2,)
     assert sorted(list(labels.numpy())) == [1, 2]
+
+
+@pytest.mark.skipif(not _IMAGE_TESTING, reason="image libraries aren't installed.")
+def test_from_data_frame_smoke(tmpdir):
+    tmpdir = Path(tmpdir)
+
+    df = pd.DataFrame({"file": ["train.png", "valid.png", "test.png"], "split": ["train", "valid", "test"],
+                       "target": [0, 1, 1]})
+
+    [_rand_image().save(tmpdir / row.file) for i, row in df.iterrows()]
+
+    img_data = ImageClassificationData.from_data_frame(
+        "file", "target",
+        train_images_root=str(tmpdir),
+        val_images_root=str(tmpdir),
+        test_images_root=str(tmpdir),
+        train_data_frame=df[df.split == "train"],
+        val_data_frame=df[df.split == "valid"],
+        test_data_frame=df[df.split == "test"],
+        predict_images_root=str(tmpdir),
+        batch_size=1,
+        predict_data_frame=df)
+
+    assert img_data.train_dataloader() is not None
+    assert img_data.val_dataloader() is not None
+    assert img_data.test_dataloader() is not None
+    assert img_data.predict_dataloader() is not None
+
+    data = next(iter(img_data.train_dataloader()))
+    imgs, labels = data["input"], data["target"]
+    assert imgs.shape == (1, 3, 196, 196)
+    assert labels.shape == (1,)
+    assert sorted(list(labels.numpy())) == [0]
+
+    data = next(iter(img_data.val_dataloader()))
+    imgs, labels = data["input"], data["target"]
+    assert imgs.shape == (1, 3, 196, 196)
+    assert labels.shape == (1,)
+    assert sorted(list(labels.numpy())) == [1]
+
+    data = next(iter(img_data.test_dataloader()))
+    imgs, labels = data["input"], data["target"]
+    assert imgs.shape == (1, 3, 196, 196)
+    assert labels.shape == (1,)
+    assert sorted(list(labels.numpy())) == [1]
+
+    data = next(iter(img_data.predict_dataloader()))
+    imgs = data["input"]
+    assert imgs.shape == (1, 3, 196, 196)
 
 
 @pytest.mark.skipif(not _IMAGE_TESTING, reason="image libraries aren't installed.")

--- a/tests/image/classification/test_data.py
+++ b/tests/image/classification/test_data.py
@@ -89,13 +89,15 @@ def test_from_filepaths_smoke(tmpdir):
 def test_from_data_frame_smoke(tmpdir):
     tmpdir = Path(tmpdir)
 
-    df = pd.DataFrame({"file": ["train.png", "valid.png", "test.png"], "split": ["train", "valid", "test"],
-                       "target": [0, 1, 1]})
+    df = pd.DataFrame(
+        {"file": ["train.png", "valid.png", "test.png"], "split": ["train", "valid", "test"], "target": [0, 1, 1]}
+    )
 
     [_rand_image().save(tmpdir / row.file) for i, row in df.iterrows()]
 
     img_data = ImageClassificationData.from_data_frame(
-        "file", "target",
+        "file",
+        "target",
         train_images_root=str(tmpdir),
         val_images_root=str(tmpdir),
         test_images_root=str(tmpdir),
@@ -104,7 +106,8 @@ def test_from_data_frame_smoke(tmpdir):
         test_data_frame=df[df.split == "test"],
         predict_images_root=str(tmpdir),
         batch_size=1,
-        predict_data_frame=df)
+        predict_data_frame=df,
+    )
 
     assert img_data.train_dataloader() is not None
     assert img_data.val_dataloader() is not None


### PR DESCRIPTION
## What does this PR do?

closes #1086

Creating an `ImageClassificationData` object with the `from_data_frame` factory method, was only working as long as i do not set 
* `predict_images_root`
* `predict_data_frame`

Fixes #1086 

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
> see #1086
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
![image](https://user-images.githubusercontent.com/19696233/147692773-12c1dbdf-8d31-4eb1-a7fb-a1bbdcdcb516.png)
> all tests in test_data.py are working
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
> always 👍 😄 
