### PR TITLE
Make Segmentation Tasks reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed a bug where passing `predict_data_frame` to `ImageClassificationData.from_data_frame` raised an error ([#1088](https://github.com/PyTorchLightning/lightning-flash/pull/1088))
 
+- Fixed a bug where segmentation files / masks were loaded with an inconsistent ordering ([#1094](https://github.com/PyTorchLightning/lightning-flash/pull/1094))
+
 ### Removed
 
 ## [0.6.0] - 2021-13-12

--- a/flash/image/segmentation/input.py
+++ b/flash/image/segmentation/input.py
@@ -124,6 +124,7 @@ class SemanticSegmentationFolderInput(SemanticSegmentationFilesInput):
     ) -> List[Dict[str, Any]]:
         self.load_labels_map(num_classes, labels_map)
         files = os.listdir(folder)
+        files.sort()
         if mask_folder is not None:
             mask_files = os.listdir(mask_folder)
 
@@ -137,6 +138,8 @@ class SemanticSegmentationFolderInput(SemanticSegmentationFilesInput):
 
             files = [os.path.join(folder, file) for file in all_files]
             mask_files = [os.path.join(mask_folder, file) for file in all_files]
+            files.sort()
+            mask_files.sort()
             return super().load_data(files, mask_files)
         return super().load_data(files)
 


### PR DESCRIPTION
## What does this PR do?
Previously, datasets created from a folder had a random order each time they were loaded. This commit fixes the order making results reproducible.

Not sure if this problem appears in any other tasks. Did a quick search for Folder Inputs of other tasks but did not find any that loaded data in a similar way.

Fixes #1060 

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
