### PR TITLE
Fix PointCloud Pretrained Backbones

### DIFF
--- a/flash/pointcloud/segmentation/open3d_ml/backbones.py
+++ b/flash/pointcloud/segmentation/open3d_ml/backbones.py
@@ -20,6 +20,7 @@ from pytorch_lightning.utilities.cloud_io import load as pl_load
 from flash.core.registry import FlashRegistry
 from flash.core.utilities.imports import _POINTCLOUD_AVAILABLE
 from flash.core.utilities.providers import _OPEN3D_ML
+from flash.core.utilities.url_error import catch_url_error
 
 ROOT_URL = "https://storage.googleapis.com/open3d-releases/model-zoo/"
 
@@ -44,36 +45,42 @@ def register_open_3d_ml(register: FlashRegistry):
             return batcher.collate_fn
 
         @register(providers=_OPEN3D_ML)
-        def randlanet_s3dis(*args, use_fold_5: bool = True, **kwargs) -> RandLANet:
+        @catch_url_error
+        def randlanet_s3dis(*args, use_fold_5: bool = True, pretrained: bool = True, **kwargs) -> RandLANet:
             cfg = _ml3d.utils.Config.load_from_file(os.path.join(CONFIG_PATH, "randlanet_s3dis.yml"))
             model = RandLANet(**cfg.model)
-            if use_fold_5:
-                weight_url = os.path.join(ROOT_URL, "randlanet_s3dis_area5_202010091333utc.pth")
-            else:
-                weight_url = os.path.join(ROOT_URL, "randlanet_s3dis_202010091238.pth")
-            model.load_state_dict(pl_load(weight_url, map_location="cpu")["model_state_dict"])
+            if pretrained:
+                if use_fold_5:
+                    weight_url = os.path.join(ROOT_URL, "randlanet_s3dis_area5_202010091333utc.pth")
+                else:
+                    weight_url = os.path.join(ROOT_URL, "randlanet_s3dis_202010091238.pth")
+                model.load_state_dict(pl_load(weight_url, map_location="cpu")["model_state_dict"])
             return model, 32, get_collate_fn(model)
 
         @register(providers=_OPEN3D_ML)
-        def randlanet_toronto3d(*args, **kwargs) -> RandLANet:
+        @catch_url_error
+        def randlanet_toronto3d(*args, pretrained: bool = True, **kwargs) -> RandLANet:
             cfg = _ml3d.utils.Config.load_from_file(os.path.join(CONFIG_PATH, "randlanet_toronto3d.yml"))
             model = RandLANet(**cfg.model)
-            model.load_state_dict(
-                pl_load(os.path.join(ROOT_URL, "randlanet_toronto3d_202010091306utc.pth"), map_location="cpu")[
-                    "model_state_dict"
-                ],
-            )
+            if pretrained:
+                model.load_state_dict(
+                    pl_load(os.path.join(ROOT_URL, "randlanet_toronto3d_202010091306utc.pth"), map_location="cpu")[
+                        "model_state_dict"
+                    ],
+                )
             return model, 32, get_collate_fn(model)
 
         @register(providers=_OPEN3D_ML)
-        def randlanet_semantic_kitti(*args, **kwargs) -> RandLANet:
+        @catch_url_error
+        def randlanet_semantic_kitti(*args, pretrained: bool = True, **kwargs) -> RandLANet:
             cfg = _ml3d.utils.Config.load_from_file(os.path.join(CONFIG_PATH, "randlanet_semantickitti.yml"))
             model = RandLANet(**cfg.model)
-            model.load_state_dict(
-                pl_load(os.path.join(ROOT_URL, "randlanet_semantickitti_202009090354utc.pth"), map_location="cpu")[
-                    "model_state_dict"
-                ],
-            )
+            if pretrained:
+                model.load_state_dict(
+                    pl_load(os.path.join(ROOT_URL, "randlanet_semantickitti_202009090354utc.pth"), map_location="cpu")[
+                        "model_state_dict"
+                    ],
+                )
             return model, 32, get_collate_fn(model)
 
         @register(providers=_OPEN3D_ML)

--- a/flash/tabular/classification/model.py
+++ b/flash/tabular/classification/model.py
@@ -93,7 +93,7 @@ class TabularClassifier(ClassificationAdapterTask):
     @staticmethod
     def _ci_benchmark_fn(history: List[Dict[str, Any]]):
         """This function is used only for debugging usage with CI."""
-        assert history[-1]["val_accuracy"] > 0.6, history[-1]["val_accuracy"]
+        assert history[-1]["valid_accuracy"] > 0.6, history[-1]["valid_accuracy"]
 
     @classmethod
     def from_data(cls, datamodule, **kwargs) -> "TabularClassifier":

--- a/tests/pointcloud/detection/test_data.py
+++ b/tests/pointcloud/detection/test_data.py
@@ -60,4 +60,4 @@ def test_pointcloud_object_detection_data(tmpdir):
 
     predictions = trainer.predict(model, datamodule=datamodule)[0]
     assert predictions[0][DataKeys.INPUT].shape[1] == 4
-    assert len(predictions[0][DataKeys.PREDS]) == 158
+    assert len(predictions[0][DataKeys.PREDS]) == 196


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Catches URL error in point cloud backbones.
Note: This is a hack since they have removed the pretrained weights. See: https://github.com/isl-org/Open3D-ML/issues/458

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
