### PR TITLE
Add `FlashRegistry` of Available Heads for `flash.image.ImageClassifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for `SemanticSegmentationData.from_folders` where mask files have different extensions to the image files ([#1130](https://github.com/PyTorchLightning/lightning-flash/pull/1130))
 
+- Added `FlashRegistry` of Available Heads for `flash.image.ImageClassifier` ([#1152](https://github.com/PyTorchLightning/lightning-flash/pull/1152))
+
 ### Changed
 
 - Changed `Wav2Vec2Processor` to `AutoProcessor` and seperate it from backbone [optional] ([#1075](https://github.com/PyTorchLightning/lightning-flash/pull/1075))

--- a/flash/core/model.py
+++ b/flash/core/model.py
@@ -832,10 +832,12 @@ class Task(DatasetProcessor, ModuleWrapperBase, LightningModule, FineTuningHooks
             self._data_pipeline_state = checkpoint["_data_pipeline_state"]
 
     @classmethod
-    def available_backbones(cls, head: Optional[str] = None) -> Union[Dict[str, List[str]], List[str]]:
+    def available_backbones(
+        cls, head: Optional[str] = None
+    ) -> Optional[Union[Dict[str, Optional[List[str]]], List[str]]]:
         if head is None:
             registry: Optional[FlashRegistry] = getattr(cls, "backbones", None)
-            if registry is not None:
+            if registry is not None and getattr(cls, "heads", None) is None:
                 return registry.available_keys()
             heads = cls.available_heads()
         else:
@@ -847,7 +849,9 @@ class Task(DatasetProcessor, ModuleWrapperBase, LightningModule, FineTuningHooks
             if "backbones" in metadata:
                 backbones = metadata["backbones"].available_keys()
             else:
-                backbones = cls.available_backbones()
+                backbones = getattr(cls, "backbones", None)
+                if backbones is not None:
+                    backbones = backbones.available_keys()
             result[head] = backbones
 
         if len(result) == 1:

--- a/flash/image/classification/heads.py
+++ b/flash/image/classification/heads.py
@@ -27,7 +27,7 @@ def _load_linear_head(num_features: int, num_classes: int) -> nn.Module:
     Args:
         num_features: Number of input features.
         num_classes: Number of output classes.
-        
+
     Returns:
         nn.Module: Linear head.
     """

--- a/flash/image/classification/heads.py
+++ b/flash/image/classification/heads.py
@@ -25,8 +25,9 @@ def _load_linear_head(num_features: int, num_classes: int) -> nn.Module:
     """Loads a linear head.
 
     Args:
-        num_features (int): Number of input features.
-        num_classes (int): Number of output classes.
+        num_features: Number of input features.
+        num_classes: Number of output classes.
+        
     Returns:
         nn.Module: Linear head.
     """
@@ -36,6 +37,4 @@ def _load_linear_head(num_features: int, num_classes: int) -> nn.Module:
 IMAGE_CLASSIFIER_HEADS(
     partial(_load_linear_head),
     name="linear",
-    namespace="image/classification",
-    providers="torch",
 )

--- a/flash/image/classification/heads.py
+++ b/flash/image/classification/heads.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from functools import partial
 
-import torch
 from torch import nn
 
 from flash.core.registry import FlashRegistry  # noqa: F401
@@ -22,40 +21,15 @@ from flash.core.registry import FlashRegistry  # noqa: F401
 IMAGE_CLASSIFIER_HEADS = FlashRegistry("classifier_heads")
 
 
-class LinearHead(nn.Module):
-    def __init__(self, num_features: int, num_classes: int) -> None:
-        """Linear head for image classification.
-
-        Args:
-            num_features (int): Number of input features.
-            num_classes (int): Number of output classes.
-        """
-        super().__init__()
-        self.linear = nn.Linear(num_features, num_classes)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass.
-
-        Args:
-            x (torch.Tensor): input tensor
-
-        Returns:
-            torch.Tensor: output tensor
-        """
-        return self.linear(x)
-
-
 def _load_linear_head(num_features: int, num_classes: int) -> nn.Module:
     """Loads a linear head.
-
     Args:
         num_features (int): Number of input features.
         num_classes (int): Number of output classes.
-
     Returns:
         nn.Module: Linear head.
     """
-    return LinearHead(num_features, num_classes)
+    return nn.Linear(num_features, num_classes)
 
 
 IMAGE_CLASSIFIER_HEADS(

--- a/flash/image/classification/heads.py
+++ b/flash/image/classification/heads.py
@@ -1,0 +1,66 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from functools import partial
+
+import torch
+from torch import nn
+
+from flash.core.registry import FlashRegistry  # noqa: F401
+
+# define ImageClassifier registry
+IMAGE_CLASSIFIER_HEADS = FlashRegistry("classifier_heads")
+
+
+class LinearHead(nn.Module):
+    def __init__(self, num_features: int, num_classes: int) -> None:
+        """Linear head for image classification.
+
+        Args:
+            num_features (int): Number of input features.
+            num_classes (int): Number of output classes.
+        """
+        super().__init__()
+        self.linear = nn.Linear(num_features, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Args:
+            x (torch.Tensor): input tensor
+
+        Returns:
+            torch.Tensor: output tensor
+        """
+        return self.linear(x)
+
+
+def _load_linear_head(num_features: int, num_classes: int) -> nn.Module:
+    """Loads a linear head.
+
+    Args:
+        num_features (int): Number of input features.
+        num_classes (int): Number of output classes.
+
+    Returns:
+        nn.Module: Linear head.
+    """
+    return LinearHead(num_features, num_classes)
+
+
+IMAGE_CLASSIFIER_HEADS(
+    partial(_load_linear_head),
+    name="linear",
+    namespace="image/classification",
+    providers="torch",
+)

--- a/flash/image/classification/heads.py
+++ b/flash/image/classification/heads.py
@@ -23,6 +23,7 @@ IMAGE_CLASSIFIER_HEADS = FlashRegistry("classifier_heads")
 
 def _load_linear_head(num_features: int, num_classes: int) -> nn.Module:
     """Loads a linear head.
+
     Args:
         num_features (int): Number of input features.
         num_classes (int): Number of output classes.

--- a/flash/image/classification/model.py
+++ b/flash/image/classification/model.py
@@ -62,6 +62,8 @@ class ImageClassifier(ClassificationAdapterTask):
     Args:
         num_classes: Number of classes to classify.
         backbone: A string or (model, num_features) tuple to use to compute image features, defaults to ``"resnet18"``.
+        head: A string from ``ImageClassifier.available_heads()``, an ``nn.Module``, or a function of (``num_features``,
+            ``num_classes``) which returns an ``nn.Module`` to use as the model head.
         pretrained: A bool or string to specify the pretrained weights of the backbone, defaults to ``True``
             which loads the default supervised pretrained weights.
         loss_fn: Loss function for training, defaults to :func:`torch.nn.functional.cross_entropy`.
@@ -89,7 +91,7 @@ class ImageClassifier(ClassificationAdapterTask):
         num_classes: Optional[int] = None,
         backbone: Union[str, Tuple[nn.Module, int]] = "resnet18",
         backbone_kwargs: Optional[Dict] = None,
-        head: Optional[Union[FunctionType, nn.Module]] = None,
+        head: Union[str, FunctionType, nn.Module] = "linear",
         pretrained: Union[bool, str] = True,
         loss_fn: LOSS_FN_TYPE = None,
         optimizer: OPTIMIZER_TYPE = "Adam",
@@ -129,9 +131,6 @@ class ImageClassifier(ClassificationAdapterTask):
             head = self.heads.get(head)(num_features=num_features, num_classes=num_classes)
         else:
             head = head(num_features, num_classes) if isinstance(head, FunctionType) else head
-            head = head or nn.Sequential(
-                nn.Linear(num_features, num_classes),
-            )
 
         adapter_from_class = self.training_strategies.get(training_strategy)
         adapter = adapter_from_class(

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -314,7 +314,7 @@ def test_available_backbones():
     class Foo(ImageClassifier):
         backbones = None
 
-    assert Foo.available_backbones() == {}
+    assert Foo.available_backbones() is None
 
 
 @ClassificationTask.lr_schedulers

--- a/tests/image/classification/test_model.py
+++ b/tests/image/classification/test_model.py
@@ -76,6 +76,15 @@ def test_init_train(tmpdir, backbone, metrics):
 
 
 @pytest.mark.skipif(not _IMAGE_TESTING, reason="image libraries aren't installed.")
+@pytest.mark.parametrize("head", [None, "linear", torch.nn.Sequential(torch.nn.Linear(512, 10))])
+def test_init_train_head(tmpdir, head):
+    model = ImageClassifier(10, backbone="resnet18", head=head, metrics=None)
+    train_dl = torch.utils.data.DataLoader(DummyDataset())
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True)
+    trainer.finetune(model, train_dl, strategy="freeze")
+
+
+@pytest.mark.skipif(not _IMAGE_TESTING, reason="image libraries aren't installed.")
 def test_non_existent_backbone():
     with pytest.raises(KeyError):
         ImageClassifier(2, "i am never going to implement this lol")

--- a/tests/image/classification/test_model.py
+++ b/tests/image/classification/test_model.py
@@ -76,7 +76,7 @@ def test_init_train(tmpdir, backbone, metrics):
 
 
 @pytest.mark.skipif(not _IMAGE_TESTING, reason="image libraries aren't installed.")
-@pytest.mark.parametrize("head", [None, "linear", torch.nn.Sequential(torch.nn.Linear(512, 10))])
+@pytest.mark.parametrize("head", ["linear", torch.nn.Linear(512, 10)])
 def test_init_train_head(tmpdir, head):
     model = ImageClassifier(10, backbone="resnet18", head=head, metrics=None)
     train_dl = torch.utils.data.DataLoader(DummyDataset())


### PR DESCRIPTION
## What does this PR do?
This PR adds a `FlashRegistry` to `flash.image.ImageClassifier`. 

Fixes #1150

## Changelog

### Added:

- ✨ added `IMAGE_CLASSIFIER_HEADS` flash registry for `flash.image.ImageClassifier`
- ✅ added unit test to test new heads registry

### Updated:

- ⚡ updated `flash.image.ImageClassifier` to use `IMAGE_CLASSIFIER_HEADS` flash registry

## Notes:

- The scope of implementation is limited to the heads currently available for `ImageClassifier`.
- All unit tests have passed locally (with `make test`)
