### PR TITLE
Expose normalization parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added the normalization parameters of ```torchvision.transforms.Normalize``` as ```transform_kwargs``` in the ```ImageClassificationInputTransform``` ([#1178](https://github.com/PyTorchLightning/lightning-flash/pull/1178))
+
 ### Changed
 
 ### Deprecated

--- a/docs/source/reference/image_classification.rst
+++ b/docs/source/reference/image_classification.rst
@@ -101,7 +101,7 @@ Here's an example:
 
     from torchvision import transforms as T
 
-    from typing import Tuple, Callable
+    from typing import Callable, Tuple, Union
     import flash
     from flash.image import ImageClassificationData, ImageClassifier
     from flash.core.data.io.input_transform import InputTransform

--- a/docs/source/reference/image_classification.rst
+++ b/docs/source/reference/image_classification.rst
@@ -112,18 +112,18 @@ Here's an example:
     class ImageClassificationInputTransform(InputTransform):
 
         image_size: Tuple[int, int] = (196, 196)
+        mean: Union[float, Tuple[float, float, float]] = (0.485, 0.456, 0.406)
+        std: Union[float, Tuple[float, float, float]] = (0.229, 0.224, 0.225)
 
         def input_per_sample_transform(self):
-            return T.Compose(
-                [T.ToTensor(), T.Resize(self.image_size), T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])]
-            )
+            return T.Compose([T.ToTensor(), T.Resize(self.image_size), T.Normalize(self.mean, self.std)])
 
         def train_input_per_sample_transform(self):
             return T.Compose(
                 [
                     T.ToTensor(),
                     T.Resize(self.image_size),
-                    T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+                    T.Normalize(self.mean, self.std),
                     T.RandomHorizontalFlip(),
                     T.ColorJitter(),
                     T.RandomAutocontrast(),

--- a/flash/image/classification/input_transform.py
+++ b/flash/image/classification/input_transform.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-from typing import Callable, Tuple
+from typing import Callable, Tuple, Union
 
 import torch
 
@@ -43,20 +43,15 @@ class AlbumentationsAdapter(torch.nn.Module):
 class ImageClassificationInputTransform(InputTransform):
 
     image_size: Tuple[int, int] = (196, 196)
+    mean: Union[float, Tuple[float, float, float]] = (0.485, 0.456, 0.406)
+    std: Union[float, Tuple[float, float, float]] = (0.229, 0.224, 0.225)
 
     def input_per_sample_transform(self):
-        return T.Compose(
-            [T.ToTensor(), T.Resize(self.image_size), T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])]
-        )
+        return T.Compose([T.ToTensor(), T.Resize(self.image_size), T.Normalize(self.mean, self.std)])
 
     def train_input_per_sample_transform(self):
         return T.Compose(
-            [
-                T.ToTensor(),
-                T.Resize(self.image_size),
-                T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
-                T.RandomHorizontalFlip(),
-            ]
+            [T.ToTensor(), T.Resize(self.image_size), T.Normalize(self.mean, self.std), T.RandomHorizontalFlip()]
         )
 
     def target_per_sample_transform(self) -> Callable:

--- a/flash_examples/image_classification.py
+++ b/flash_examples/image_classification.py
@@ -24,7 +24,7 @@ datamodule = ImageClassificationData.from_folders(
     train_folder="data/hymenoptera_data/train/",
     val_folder="data/hymenoptera_data/val/",
     batch_size=4,
-    transform_kwargs={"image_size": (196, 196)},
+    transform_kwargs={"image_size": (196, 196), "mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
 )
 
 # 2. Build the task


### PR DESCRIPTION
## What does this PR do?
This PR exposes the normalization parameters of ```torchvision.transforms.Normalize``` as ```transform_kwargs``` in the ```ImageClassificationInputTransform```.

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
