### PR TITLE
Use 512 as image size for object detection example

### DIFF
--- a/flash_examples/object_detection.py
+++ b/flash_examples/object_detection.py
@@ -23,12 +23,12 @@ datamodule = ObjectDetectionData.from_coco(
     train_folder="data/coco128/images/train2017/",
     train_ann_file="data/coco128/annotations/instances_train2017.json",
     val_split=0.1,
-    transform_kwargs={"image_size": 128},
+    transform_kwargs={"image_size": 512},
     batch_size=4,
 )
 
 # 2. Build the task
-model = ObjectDetector(head="efficientdet", backbone="d0", num_classes=datamodule.num_classes, image_size=128)
+model = ObjectDetector(head="efficientdet", backbone="d0", num_classes=datamodule.num_classes, image_size=512)
 
 # 3. Create the trainer and finetune the model
 trainer = flash.Trainer(max_epochs=1)
@@ -41,7 +41,7 @@ datamodule = ObjectDetectionData.from_files(
         "data/coco128/images/train2017/000000000626.jpg",
         "data/coco128/images/train2017/000000000629.jpg",
     ],
-    transform_kwargs={"image_size": 128},
+    transform_kwargs={"image_size": 512},
     batch_size=4,
 )
 predictions = trainer.predict(model, datamodule=datamodule)


### PR DESCRIPTION
The efficientdet d0's default image size is 512x512. So use 512 as the image size will give a much better performance.

Follow the discussion: https://github.com/PyTorchLightning/lightning-flash/discussions/1191#discussioncomment-2235172

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Give a much better benchmark to object detection example. If the example can not give a good result how can you expect people to use it? They may go away...

Fixes # (issue)

## Before submitting
- [] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

 - [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
