### PR TITLE
Bugfix: `_show_images_and_labels` - flatten axes to allow plotting for subplots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed `_show_images_and_labels` for subplots with rows > 1. ([#1339](https://github.com/PyTorchLightning/lightning-flash/pull/1315))
+- Fixed image classification data `show_train_batch` for subplots with rows > 1. ([#1339](https://github.com/PyTorchLightning/lightning-flash/pull/1315))
 
 - Fixed support for all the versions (including the latest and older) of `baal`. ([#1315](https://github.com/PyTorchLightning/lightning-flash/pull/1315))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `_show_images_and_labels` for subplots with rows > 1. ([#1339](https://github.com/PyTorchLightning/lightning-flash/pull/1315))
+
 - Fixed support for all the versions (including the latest and older) of `baal`. ([#1315](https://github.com/PyTorchLightning/lightning-flash/pull/1315))
 
 - Fixed a bug where a loaded `TabularClassifier` or `TabularRegressor` checkpoint could not be served ([#1324](https://github.com/PyTorchLightning/lightning-flash/pull/1324))

--- a/flash/image/classification/data.py
+++ b/flash/image/classification/data.py
@@ -1061,7 +1061,8 @@ class MatplotlibVisualization(BaseVisualization):
         fig.suptitle(title)
 
         if not isinstance(axs, np.ndarray):
-            axs = [axs]
+            axs = np.array(axs)
+        axs = axs.flatten()
 
         for i, ax in enumerate(axs):
             # unpack images and labels

--- a/tests/image/classification/test_data.py
+++ b/tests/image/classification/test_data.py
@@ -257,6 +257,40 @@ def test_from_filepaths_visualise_subplots_exceding_max_cols(tmpdir):
 
 @pytest.mark.skipif(not _IMAGE_AVAILABLE, reason="image libraries aren't installed.")
 @pytest.mark.skipif(not _MATPLOTLIB_AVAILABLE, reason="matplotlib isn't installed.")
+def test_from_filepaths_visualise_subplots_single_image(tmpdir):
+    tmpdir = Path(tmpdir)
+
+    (tmpdir / "e").mkdir()
+    _rand_image().save(tmpdir / "e_1.png")
+
+    train_images = [
+        str(tmpdir / "e_1.png"),
+    ]
+
+    dm = ImageClassificationData.from_files(
+        train_files=train_images,
+        train_targets=[0],
+        val_files=train_images,
+        val_targets=[1],
+        test_files=train_images,
+        test_targets=[2],
+        batch_size=1,
+        num_workers=0,
+    )
+
+    # disable visualisation for testing
+    assert dm.data_fetcher.block_viz_window is True
+    dm.set_block_viz_window(False)
+    assert dm.data_fetcher.block_viz_window is False
+
+    # call show functions
+    # dm.show_train_batch()
+    dm.show_train_batch("per_sample_transform")
+    dm.show_train_batch(["per_sample_transform", "per_batch_transform"])
+
+
+@pytest.mark.skipif(not _IMAGE_AVAILABLE, reason="image libraries aren't installed.")
+@pytest.mark.skipif(not _MATPLOTLIB_AVAILABLE, reason="matplotlib isn't installed.")
 def test_from_filepaths_visualise_multilabel(tmpdir):
     tmpdir = Path(tmpdir)
 

--- a/tests/image/classification/test_data.py
+++ b/tests/image/classification/test_data.py
@@ -223,6 +223,40 @@ def test_from_filepaths_visualise(tmpdir):
 
 @pytest.mark.skipif(not _IMAGE_AVAILABLE, reason="image libraries aren't installed.")
 @pytest.mark.skipif(not _MATPLOTLIB_AVAILABLE, reason="matplotlib isn't installed.")
+def test_from_filepaths_visualise_subplots_exceding_max_cols(tmpdir):
+    tmpdir = Path(tmpdir)
+
+    (tmpdir / "e").mkdir()
+    _rand_image().save(tmpdir / "e_1.png")
+
+    train_images = [
+        str(tmpdir / "e_1.png"),
+    ] * 8
+
+    dm = ImageClassificationData.from_files(
+        train_files=train_images,
+        train_targets=[0, 3, 6, 9, 8, 9, 1, 2],
+        val_files=train_images,
+        val_targets=[1, 4, 7, 8, 9, 8, 7, 1],
+        test_files=train_images,
+        test_targets=[2, 5, 8, 9, 7, 1, 2, 3],
+        batch_size=8,
+        num_workers=0,
+    )
+
+    # disable visualisation for testing
+    assert dm.data_fetcher.block_viz_window is True
+    dm.set_block_viz_window(False)
+    assert dm.data_fetcher.block_viz_window is False
+
+    # call show functions
+    # dm.show_train_batch()
+    dm.show_train_batch("per_sample_transform")
+    dm.show_train_batch(["per_sample_transform", "per_batch_transform"])
+
+
+@pytest.mark.skipif(not _IMAGE_AVAILABLE, reason="image libraries aren't installed.")
+@pytest.mark.skipif(not _MATPLOTLIB_AVAILABLE, reason="matplotlib isn't installed.")
 def test_from_filepaths_visualise_multilabel(tmpdir):
     tmpdir = Path(tmpdir)
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/PyTorchLightning/lightning-flash/issues/1323.

The following script will fail:

```python
import matplotlib.pyplot as plt
import numpy as np

fig, axs = plt.subplots(2, 2)
for i, ax in enumerate(axs):
    ax.imshow(np.random.randint(1, 255, (5, 5, 3)))
```

Note that the object "ax" is still a `list/ndarray` here, and not an Axes object, so we should flatten the `axs` object before looping through it. (for some discussion: https://stackoverflow.com/questions/43957776/numpy-ndarray-object-has-no-attribute-imshow)

## Before submitting
- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? [not needed for typos/docs]
- [x] Did you verify **new and existing tests pass** locally with your changes?
- [x] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
