### PR TITLE
Fix un-usability of manual optimization in Flash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed a bug where the backbone learning rate would be divided by 10 when unfrozen if using the `freeze_unfreeze` or `unfreeze_milestones` strategies ([#1329](https://github.com/PyTorchLightning/lightning-flash/pull/1329))
 
+- Fixed naming of optimizer and scheduler registries which did not allow manual optimization. ([#1342](https://github.com/PyTorchLightning/lightning-flash/pull/1342))
+
 ## [0.7.4] - 2022-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ model = ImageClassifier(backbone="resnet18", num_classes=2, optimizer="Adam", lr
 You can also register you own custom scheduler recipes beforeahand and use them shown as above:
 
 ```py
-@ImageClassifier.lr_schedulers
+@ImageClassifier.lr_schedulers_registry
 def my_steplr_recipe(optimizer):
     return torch.optim.lr_scheduler.StepLR(optimizer, step_size=10)
 

--- a/docs/source/general/optimization.rst
+++ b/docs/source/general/optimization.rst
@@ -176,7 +176,7 @@ Using the ``optimizers`` and ``lr_schedulers`` decorator pertaining to each :cla
 
     >>> import torch
     >>> from flash.image import ImageClassifier
-    >>> @ImageClassifier.lr_schedulers
+    >>> @ImageClassifier.lr_schedulers_registry
     ... def my_flash_steplr_recipe(optimizer):
     ...     return torch.optim.lr_scheduler.StepLR(optimizer, step_size=10)
     ...

--- a/flash/core/model.py
+++ b/flash/core/model.py
@@ -324,8 +324,8 @@ class Task(DatasetProcessor, ModuleWrapperBase, LightningModule, FineTuningHooks
             task.
     """
 
-    optimizers: FlashRegistry = _OPTIMIZERS_REGISTRY
-    lr_schedulers: FlashRegistry = _SCHEDULERS_REGISTRY
+    optimizers_registry: FlashRegistry = _OPTIMIZERS_REGISTRY
+    lr_schedulers_registry: FlashRegistry = _SCHEDULERS_REGISTRY
     finetuning_strategies: FlashRegistry = _FINETUNING_STRATEGIES_REGISTRY
     outputs: FlashRegistry = BASE_OUTPUTS
 
@@ -490,7 +490,7 @@ class Task(DatasetProcessor, ModuleWrapperBase, LightningModule, FineTuningHooks
                 f"\nUse `{self.__class__.__name__}.available_optimizers()` to list the available optimizers."
                 f"\nList of available Optimizers: {self.available_optimizers()}."
             )
-        optimizer_fn = self.optimizers.get(optimizer_key.lower())
+        optimizer_fn = self.optimizers_registry.get(optimizer_key.lower())
         return optimizer_fn
 
     def configure_optimizers(self) -> Union[Optimizer, Tuple[List[Optimizer], List[_LRScheduler]]]:
@@ -614,7 +614,7 @@ class Task(DatasetProcessor, ModuleWrapperBase, LightningModule, FineTuningHooks
     @classmethod
     def available_optimizers(cls) -> List[str]:
         """Returns a list containing the keys of the available Optimizers."""
-        registry: Optional[FlashRegistry] = getattr(cls, "optimizers", None)
+        registry: Optional[FlashRegistry] = getattr(cls, "optimizers_registry", None)
         if registry is None:
             return []
         return registry.available_keys()
@@ -622,7 +622,7 @@ class Task(DatasetProcessor, ModuleWrapperBase, LightningModule, FineTuningHooks
     @classmethod
     def available_lr_schedulers(cls) -> List[str]:
         """Returns a list containing the keys of the available LR schedulers."""
-        registry: Optional[FlashRegistry] = getattr(cls, "lr_schedulers", None)
+        registry: Optional[FlashRegistry] = getattr(cls, "lr_schedulers_registry", None)
         if registry is None:
             return []
         return registry.available_keys()
@@ -683,7 +683,7 @@ class Task(DatasetProcessor, ModuleWrapperBase, LightningModule, FineTuningHooks
                 f"\nUse `{self.__class__.__name__}.available_lr_schedulers()` to list the available schedulers."
                 f"\n>>> List of available LR Schedulers: {self.available_lr_schedulers()}."
             )
-        lr_scheduler_fn: Dict[str, Any] = self.lr_schedulers.get(lr_scheduler_key.lower(), with_metadata=True)
+        lr_scheduler_fn: Dict[str, Any] = self.lr_schedulers_registry.get(lr_scheduler_key.lower(), with_metadata=True)
         return deepcopy(lr_scheduler_fn)
 
     def _instantiate_lr_scheduler(self, optimizer: Optimizer) -> Dict[str, Any]:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -40,29 +40,18 @@ from flash.core.data.io.output_transform import OutputTransform
 from flash.core.utilities.imports import (
     _AUDIO_TESTING,
     _CORE_TESTING,
-    _GRAPH_AVAILABLE,
     _GRAPH_TESTING,
     _IMAGE_AVAILABLE,
     _IMAGE_TESTING,
-    _TABULAR_AVAILABLE,
     _TABULAR_TESTING,
-    _TEXT_AVAILABLE,
     _TEXT_TESTING,
     _TORCH_OPTIMIZER_AVAILABLE,
     _TRANSFORMERS_AVAILABLE,
 )
-
-if _GRAPH_AVAILABLE:
-    from flash.graph import GraphClassifier, GraphEmbedder
-
-if _IMAGE_AVAILABLE:
-    from flash.image import ImageClassifier, SemanticSegmentation
-
-if _TABULAR_AVAILABLE:
-    from flash.tabular import TabularClassifier
-
-if _TEXT_AVAILABLE:
-    from flash.text import SummarizationTask, TextClassifier, TranslationTask
+from flash.graph import GraphClassifier, GraphEmbedder
+from flash.image import ImageClassifier, SemanticSegmentation
+from flash.tabular import TabularClassifier
+from flash.text import SummarizationTask, TextClassifier, TranslationTask
 
 # ======== Mock functions ========
 


### PR DESCRIPTION
## What does this PR do?

In a Flash Task, `self.optimizers()` and `self.lr_schedulers()` point to the respective Flash Registry instead of returning the optimizers and the lr schedulers used by the training job. This stands in the way of performing manual optimization.

This PR attempts to fix this issue.

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? [not needed for typos/docs]
- [x] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
