### PR TITLE
Freeze versions of `protobuf` and `omegaconf`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0
 click>=7.1.2
 protobuf==3.20.1
-omegaconf==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0
 click>=7.1.2
 protobuf==3.20.1
+omegaconf==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyDeprecate
 pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0
 click>=7.1.2
+protobuf==3.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pyDeprecate
 pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0
 click>=7.1.2
-protobuf==3.20.1
+protobuf<=3.20.1

--- a/requirements/datatype_tabular.txt
+++ b/requirements/datatype_tabular.txt
@@ -2,4 +2,4 @@ scikit-learn
 pytorch-forecasting>=0.9.0
 pytorch-tabular==0.7.0
 torchmetrics<0.8.0  # pytorch-tabular pins PL so we force a compatible TM version
-omegaconf==2.1.1
+omegaconf<=2.1.1

--- a/requirements/datatype_tabular.txt
+++ b/requirements/datatype_tabular.txt
@@ -2,3 +2,4 @@ scikit-learn
 pytorch-forecasting>=0.9.0
 pytorch-tabular==0.7.0
 torchmetrics<0.8.0  # pytorch-tabular pins PL so we force a compatible TM version
+omegaconf==2.1.1


### PR DESCRIPTION
## What does this PR do?

The recent release of  the 
- `protobuf` package, a dependency of the `tensorboard` package, to `protobuf-4.21.0rc1` 
- `omegaconf` package, a dependeny of tabular tasks requirements, to `omegaconf~2.2.1`

have breaking changes which fails all tests.

Hence freezing the version to recent most latest version.
<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [ ] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
